### PR TITLE
Enhance logging across client, server, and ARQ layers

### DIFF
--- a/internal/arq/arq.go
+++ b/internal/arq/arq.go
@@ -56,6 +56,7 @@ type queuedDataNackRemover interface {
 type Logger interface {
 	Debugf(format string, args ...any)
 	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
 	Errorf(format string, args ...any)
 }
 
@@ -63,6 +64,7 @@ type dummyLogger struct{}
 
 func (d *dummyLogger) Debugf(f string, a ...any) {}
 func (d *dummyLogger) Infof(f string, a ...any)  {}
+func (d *dummyLogger) Warnf(f string, a ...any)  {}
 func (d *dummyLogger) Errorf(f string, a ...any) {}
 
 type arqDataItem struct {
@@ -1899,6 +1901,7 @@ func (a *ARQ) checkRetransmits() {
 			}
 		} else if now.Sub(info.CreatedAt) >= a.dataPacketTTL && info.Retries >= a.maxDataRetries {
 			a.mu.Unlock()
+			a.logger.Debugf("⚠️ <yellow>ARQ max retransmissions <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Session: <cyan>%d</cyan> <magenta>|</magenta> SN: <cyan>%d</cyan></yellow>", a.streamID, a.sessionID, sn)
 			a.Close("Max retransmissions exceeded", CloseOptions{SendRST: true})
 			return
 		}
@@ -2103,7 +2106,9 @@ func (a *ARQ) handleTerminalRetransmitState(now time.Time) bool {
 			return false
 		}
 
+		idleDur := now.Sub(a.lastActivity)
 		a.mu.Unlock()
+		a.logger.Debugf("⏰ <yellow>ARQ inactivity timeout <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Session: <cyan>%d</cyan> <magenta>|</magenta> Idle: <cyan>%s</cyan></yellow>", a.streamID, a.sessionID, idleDur.Truncate(time.Second))
 		a.Close("Stream Inactivity Timeout (Dead)", CloseOptions{SendRST: true})
 		return true
 	}
@@ -2146,6 +2151,7 @@ func (a *ARQ) checkControlRetransmits(now time.Time) {
 				if exceededRetries {
 					reason = "Control packet max retransmissions exceeded"
 				}
+				a.logger.Debugf("⚠️ <yellow>ARQ control expired <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Type: <cyan>0x%02x</cyan> <magenta>|</magenta> Reason: <cyan>%s</cyan></yellow>", a.streamID, info.PacketType, reason)
 				a.mu.Unlock()
 				a.handleTrackedPacketTTLExpiry(info.PacketType, reason)
 				a.mu.Lock()
@@ -2166,6 +2172,7 @@ func (a *ARQ) checkControlRetransmits(now time.Time) {
 			continue
 		}
 
+		a.logger.Debugf("🔄 <yellow>ARQ control retransmit <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Type: <cyan>0x%02x</cyan> <magenta>|</magenta> Retry: <cyan>%d</cyan></yellow>", a.streamID, info.PacketType, info.Retries+1)
 		info.LastSentAt = now
 		info.Dispatched = false
 		info.Retries++

--- a/internal/arq/arq_test.go
+++ b/internal/arq/arq_test.go
@@ -90,6 +90,7 @@ type testLogger struct {
 
 func (l *testLogger) Debugf(format string, args ...any) { l.t.Logf("[DEBUG] "+format, args...) }
 func (l *testLogger) Infof(format string, args ...any)  { l.t.Logf("[INFO] "+format, args...) }
+func (l *testLogger) Warnf(format string, args ...any)  { l.t.Logf("[WARN] "+format, args...) }
 func (l *testLogger) Errorf(format string, args ...any) { l.t.Logf("[ERROR] "+format, args...) }
 
 type eofAfterDataConn struct {

--- a/internal/client/async_runtime.go
+++ b/internal/client/async_runtime.go
@@ -20,6 +20,7 @@ import (
 	"masterdnsvpn-go/internal/client/handlers"
 	DnsParser "masterdnsvpn-go/internal/dnsparser"
 	fragmentStore "masterdnsvpn-go/internal/fragmentstore"
+	"masterdnsvpn-go/internal/logger"
 )
 
 const clientRXDropLogInterval = 2 * time.Second
@@ -296,7 +297,11 @@ func (c *Client) StartAsyncRuntime(parentCtx context.Context) error {
 		}()
 	}
 
-	// 10. Lifecycle cleanup.
+	// 10. Periodic stats logger.
+	c.asyncWG.Add(1)
+	go c.asyncStatsLogger(runtimeCtx)
+
+	// 11. Lifecycle cleanup.
 	c.asyncWG.Add(1)
 	go func() {
 		defer c.asyncWG.Done()
@@ -375,6 +380,72 @@ func (c *Client) asyncStreamCleanupWorker(ctx context.Context) {
 			for _, streamID := range removeIDs {
 				c.removeStream(streamID)
 			}
+		}
+	}
+}
+
+// asyncStatsLogger periodically logs connection and stream statistics.
+func (c *Client) asyncStatsLogger(ctx context.Context) {
+	defer c.asyncWG.Done()
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.logPeriodicStats()
+		}
+	}
+}
+
+func (c *Client) logPeriodicStats() {
+	if c.log == nil {
+		return
+	}
+
+	// Stream stats
+	c.streamsMu.RLock()
+	total := len(c.active_streams)
+	active, draining, pending := 0, 0, 0
+	for _, s := range c.active_streams {
+		if s == nil {
+			continue
+		}
+		switch s.StatusValue() {
+		case streamStatusActive:
+			active++
+		case streamStatusDraining, streamStatusClosing, streamStatusTimeWait:
+			draining++
+		case streamStatusPending, streamStatusSocksConnecting:
+			pending++
+		}
+	}
+	c.streamsMu.RUnlock()
+
+	// Balancer stats
+	bs := c.balancer.Stats()
+
+	c.log.Debugf(
+		"📊 <green>Stats <magenta>|</magenta> Streams: <cyan>%d</cyan> active, <cyan>%d</cyan> pending, <cyan>%d</cyan> draining (<cyan>%d</cyan> total) <magenta>|</magenta> Resolvers: <cyan>%d</cyan>/<cyan>%d</cyan> valid</green>",
+		active, pending, draining, total, bs.Valid, bs.Total,
+	)
+
+	if c.log.Enabled(logger.LevelDebug) {
+		for _, e := range bs.Entries {
+			var lossStr string
+			if e.Sent > 0 {
+				lossPct := float64(e.Sent-e.Acked) * 100 / float64(e.Sent)
+				lossStr = fmt.Sprintf("%.1f%%", lossPct)
+			} else {
+				lossStr = "N/A"
+			}
+			c.log.Debugf(
+				"📊 <cyan>Resolver %s <magenta>|</magenta> Valid: <cyan>%t</cyan> <magenta>|</magenta> Sent: <cyan>%d</cyan> <magenta>|</magenta> Acked: <cyan>%d</cyan> <magenta>|</magenta> Loss: <cyan>%s</cyan> <magenta>|</magenta> AvgRTT: <cyan>%dms</cyan></cyan>",
+				e.Key, e.Valid, e.Sent, e.Acked, lossStr, e.AvgRTTMicro/1000,
+			)
 		}
 	}
 }

--- a/internal/client/balancer.go
+++ b/internal/client/balancer.go
@@ -596,3 +596,54 @@ func xorshift64(v uint64) uint64 {
 	v ^= v << 17
 	return v
 }
+
+// ConnectionStatEntry holds per-resolver stats for periodic reporting.
+type ConnectionStatEntry struct {
+	Key         string
+	Valid       bool
+	Sent        uint64
+	Acked       uint64
+	AvgRTTMicro uint64
+}
+
+// BalancerStats holds aggregated snapshot stats.
+type BalancerStats struct {
+	Total   int
+	Valid   int
+	Entries []ConnectionStatEntry
+}
+
+// Stats returns a snapshot of per-connection statistics.
+func (b *Balancer) Stats() BalancerStats {
+	snap := b.snapshot.Load()
+	if snap == nil {
+		return BalancerStats{}
+	}
+
+	entries := make([]ConnectionStatEntry, 0, len(snap.connections))
+	for idx, conn := range snap.connections {
+		if conn == nil {
+			continue
+		}
+		entry := ConnectionStatEntry{
+			Key:   conn.Key,
+			Valid: conn.IsValid,
+		}
+		if idx < len(snap.stats) && snap.stats[idx] != nil {
+			s := snap.stats[idx]
+			entry.Sent = s.sent.Load()
+			entry.Acked = s.acked.Load()
+			cnt := s.rttCount.Load()
+			if cnt > 0 {
+				entry.AvgRTTMicro = s.rttMicrosSum.Load() / cnt
+			}
+		}
+		entries = append(entries, entry)
+	}
+
+	return BalancerStats{
+		Total:   len(snap.connections),
+		Valid:   len(snap.valid),
+		Entries: entries,
+	}
+}

--- a/internal/client/session.go
+++ b/internal/client/session.go
@@ -51,6 +51,9 @@ func (c *Client) InitializeSession(maxAttempts int) error {
 		}
 	}
 
+	if c.log != nil {
+		c.log.Debugf("⚠️ <yellow>Session init failed after <cyan>%d</cyan> attempts</yellow>", maxAttempts)
+	}
 	return ErrSessionInitFailed
 }
 
@@ -62,11 +65,17 @@ func (c *Client) initializeSessionOnce() error {
 
 	query, err := c.buildSessionQuery(conn.Domain, Enums.PACKET_SESSION_INIT, initPayload)
 	if err != nil {
+		if c.log != nil {
+			c.log.Debugf("⚠️ <yellow>Session init query build failed: <cyan>%v</cyan></yellow>", err)
+		}
 		return ErrSessionInitFailed
 	}
 
 	packet, err := c.exchangeDNSOverConnection(conn, query, c.mtuTestTimeout)
 	if err != nil {
+		if c.log != nil {
+			c.log.Debugf("🔄 <yellow>Session init DNS exchange failed: <cyan>%v</cyan></yellow>", err)
+		}
 		return ErrSessionInitFailed
 	}
 
@@ -75,7 +84,11 @@ func (c *Client) initializeSessionOnce() error {
 		if len(packet.Payload) < sessionBusyPayloadSize || !bytes.Equal(packet.Payload[:sessionBusyPayloadSize], verifyCode[:]) {
 			return ErrSessionInitFailed
 		}
-		c.setSessionInitBusyUntil(time.Now().Add(c.cfg.SessionInitBusyRetryInterval()))
+		busyRetry := c.cfg.SessionInitBusyRetryInterval()
+		c.setSessionInitBusyUntil(time.Now().Add(busyRetry))
+		if c.log != nil {
+			c.log.Debugf("⚠️ <yellow>Server busy, retry after <cyan>%s</cyan></yellow>", busyRetry)
+		}
 		return ErrSessionInitBusy
 	case Enums.PACKET_SESSION_ACCEPT:
 		if len(packet.Payload) < sessionAcceptPayloadSize || !bytes.Equal(packet.Payload[3:7], verifyCode[:]) {
@@ -91,6 +104,14 @@ func (c *Client) initializeSessionOnce() error {
 		c.clearSessionInitBusyUntil()
 		c.resetSessionInitState()
 		c.clearSessionResetPending()
+		if c.log != nil {
+			c.log.Debugf(
+				"✅ <green>Session Accepted <magenta>|</magenta> ID: <cyan>%d</cyan> <magenta>|</magenta> Cookie: <cyan>%d</cyan> <magenta>|</magenta> Upload: <cyan>%s</cyan> <magenta>|</magenta> Download: <cyan>%s</cyan></green>",
+				c.sessionID, c.sessionCookie,
+				compression.TypeName(c.uploadCompression),
+				compression.TypeName(c.downloadCompression),
+			)
+		}
 		return nil
 	default:
 		return ErrSessionInitFailed
@@ -319,6 +340,9 @@ func (c *Client) sendSessionCloseRound(targets []Connection, deadline time.Time)
 				PacketType:    Enums.PACKET_SESSION_CLOSE,
 			})
 			if err != nil {
+				if c.log != nil {
+					c.log.Debugf("⚠️ <yellow>Session close query build failed: <cyan>%v</cyan></yellow>", err)
+				}
 				return
 			}
 			c.sendOneWayDNSQuery(conn, query, deadline)

--- a/internal/client/socks_manager.go
+++ b/internal/client/socks_manager.go
@@ -69,6 +69,9 @@ func (c *Client) supportsSOCKS4() bool {
 func (c *Client) HandleSOCKS5(ctx context.Context, conn net.Conn) {
 	version := make([]byte, 1)
 	if _, err := io.ReadFull(conn, version); err != nil {
+		if c.log != nil {
+			c.log.Debugf("🔌 <yellow>SOCKS handshake read failed: <cyan>%v</cyan></yellow>", err)
+		}
 		_ = conn.Close()
 		return
 	}
@@ -83,6 +86,9 @@ func (c *Client) HandleSOCKS5(ctx context.Context, conn net.Conn) {
 		}
 		c.handleSOCKS4Request(ctx, conn)
 	default:
+		if c.log != nil {
+			c.log.Debugf("🔌 <yellow>SOCKS unknown version: <cyan>0x%02x</cyan></yellow>", version[0])
+		}
 		_ = conn.Close()
 	}
 }
@@ -662,7 +668,7 @@ func (c *Client) HandleSocksConnected(packet VpnProto.Packet) error {
 		arqObj.SetIOReady(true)
 	}
 
-	c.log.Debugf("🔌 <green>Socks successfully connected for stream %d</green>", packet.StreamID)
+	c.log.Debugf("🔌 <green>SOCKS connected <magenta>|</magenta> Stream: <cyan>%d</cyan></green>", packet.StreamID)
 	return nil
 }
 
@@ -706,6 +712,7 @@ func (c *Client) HandleSocksFailure(packet VpnProto.Packet) error {
 		return nil
 	}
 
+	c.log.Debugf("🔌 <yellow>SOCKS failure <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> PacketType: <cyan>0x%02x</cyan></yellow>", packet.StreamID, packet.PacketType)
 	arqObj.Close("SOCKS failure received", arq.CloseOptions{Force: true})
 	return nil
 }

--- a/internal/client/stream_client.go
+++ b/internal/client/stream_client.go
@@ -183,6 +183,13 @@ func (c *Client) new_stream(streamID uint16, conn net.Conn, targetPayload []byte
 		c.ensureStreamPreferredConnection(s)
 	}
 
+	if c.log != nil && streamID != 0 {
+		c.log.Debugf(
+			"🧦 <green>Stream Created <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Session: <cyan>%d</cyan> <magenta>|</magenta> Status: <cyan>%s</cyan></green>",
+			streamID, c.sessionID, s.StatusValue(),
+		)
+	}
+
 	return s
 }
 
@@ -327,6 +334,13 @@ func (s *Stream_client) RemoveQueuedDataNack(sequenceNum uint16) bool {
 }
 
 func (s *Stream_client) cleanupResources() {
+	if s.client != nil && s.client.log != nil && s.StreamID != 0 {
+		s.client.log.Debugf(
+			"🧹 <yellow>Stream Cleanup <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Session: <cyan>%d</cyan></yellow>",
+			s.StreamID, s.client.sessionID,
+		)
+	}
+
 	if s.NetConn != nil {
 		_ = s.NetConn.Close()
 	}
@@ -611,6 +625,10 @@ func (c *Client) CloseAllStreams() {
 	c.active_streams = make(map[uint16]*Stream_client)
 	c.streamsMu.Unlock()
 	c.bumpStreamSetVersion()
+
+	if c.log != nil {
+		c.log.Debugf("🧦 <yellow>Closing all streams <magenta>|</magenta> Count: <cyan>%d</cyan></yellow>", len(streams))
+	}
 
 	for _, s := range streams {
 		if s != nil {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -167,6 +167,40 @@ func (l *Logger) Enabled(level int) bool {
 	return l != nil && level >= l.level
 }
 
+// SubLogger wraps a Logger with a pre-rendered context prefix (e.g. "[Sess:3] [Str:42]").
+// It satisfies the arq.Logger interface and can be chained via With().
+type SubLogger struct {
+	parent *Logger
+	prefix string
+}
+
+// With creates a SubLogger with a single [key:value] context field.
+func (l *Logger) With(key, value string) *SubLogger {
+	return &SubLogger{parent: l, prefix: "[" + key + ":" + value + "]"}
+}
+
+// With chains an additional [key:value] context field onto an existing SubLogger.
+func (s *SubLogger) With(key, value string) *SubLogger {
+	return &SubLogger{parent: s.parent, prefix: s.prefix + " [" + key + ":" + value + "]"}
+}
+
+func (s *SubLogger) Debugf(format string, args ...any) {
+	s.parent.logf(levelDebug, s.prefix+" "+format, args...)
+}
+func (s *SubLogger) Infof(format string, args ...any) {
+	s.parent.logf(levelInfo, s.prefix+" "+format, args...)
+}
+func (s *SubLogger) Warnf(format string, args ...any) {
+	s.parent.logf(levelWarn, s.prefix+" "+format, args...)
+}
+func (s *SubLogger) Errorf(format string, args ...any) {
+	s.parent.logf(levelError, s.prefix+" "+format, args...)
+}
+
+func (s *SubLogger) Enabled(level int) bool {
+	return s.parent.Enabled(level)
+}
+
 func stripColorTags(text string) string {
 	start := strings.IndexByte(text, '<')
 	if start == -1 {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -93,3 +93,76 @@ func TestShouldUseColorHonorsNoColor(t *testing.T) {
 		t.Fatal("NO_COLOR should disable colors even when FORCE_COLOR is set")
 	}
 }
+
+func TestSubLoggerPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{
+		name:          "test",
+		level:         levelDebug,
+		consoleWriter: &buf,
+		color:         false,
+		appNameText:   "[test]",
+	}
+
+	sub := l.With("Sess", "3")
+	sub.Infof("hello %s", "world")
+
+	output := buf.String()
+	if !strings.Contains(output, "[Sess:3] hello world") {
+		t.Fatalf("expected prefix in output, got: %s", output)
+	}
+}
+
+func TestSubLoggerChaining(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{
+		name:          "test",
+		level:         levelDebug,
+		consoleWriter: &buf,
+		color:         false,
+		appNameText:   "[test]",
+	}
+
+	sub := l.With("Sess", "3").With("Str", "42")
+	sub.Debugf("stream opened")
+
+	output := buf.String()
+	if !strings.Contains(output, "[Sess:3] [Str:42] stream opened") {
+		t.Fatalf("expected chained prefix in output, got: %s", output)
+	}
+}
+
+func TestSubLoggerRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{
+		name:          "test",
+		level:         levelWarn,
+		consoleWriter: &buf,
+		color:         false,
+		appNameText:   "[test]",
+	}
+
+	sub := l.With("Sess", "1")
+	sub.Debugf("should not appear")
+	sub.Infof("should not appear")
+	sub.Warnf("should appear")
+
+	output := buf.String()
+	if strings.Contains(output, "should not appear") {
+		t.Fatal("sub-logger should suppress below parent level")
+	}
+	if !strings.Contains(output, "should appear") {
+		t.Fatal("sub-logger should log at parent level")
+	}
+}
+
+func TestSubLoggerEnabled(t *testing.T) {
+	l := &Logger{level: levelWarn}
+	sub := l.With("X", "1")
+	if sub.Enabled(levelDebug) {
+		t.Fatal("Enabled(debug) should be false at warn level")
+	}
+	if !sub.Enabled(levelWarn) {
+		t.Fatal("Enabled(warn) should be true at warn level")
+	}
+}

--- a/internal/udpserver/server.go
+++ b/internal/udpserver/server.go
@@ -219,6 +219,8 @@ func (s *Server) Run(ctx context.Context) error {
 		s.sessionCleanupLoop(runCtx)
 	}()
 
+	go s.serverStatsLogger(runCtx)
+
 	s.deferredDNSSession.Start(runCtx)
 	s.deferredConnectSession.Start(runCtx)
 	s.startDNSWorkers(runCtx, conn, reqCh, &workerWG)
@@ -248,4 +250,43 @@ func (s *Server) Run(ctx context.Context) error {
 	default:
 		return nil
 	}
+}
+
+func (s *Server) serverStatsLogger(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.logServerStats()
+		}
+	}
+}
+
+func (s *Server) logServerStats() {
+	if s.log == nil || !s.log.Enabled(logger.LevelDebug) {
+		return
+	}
+
+	s.sessions.mu.Lock()
+	activeSessions := 0
+	totalStreams := 0
+	for _, record := range s.sessions.byID {
+		if record == nil {
+			continue
+		}
+		activeSessions++
+		record.StreamsMu.RLock()
+		totalStreams += len(record.ActiveStreams)
+		record.StreamsMu.RUnlock()
+	}
+	s.sessions.mu.Unlock()
+
+	s.log.Debugf(
+		"📊 <green>Server Stats <magenta>|</magenta> Sessions: <cyan>%d</cyan> <magenta>|</magenta> Streams: <cyan>%d</cyan></green>",
+		activeSessions, totalStreams,
+	)
 }

--- a/internal/udpserver/server_session.go
+++ b/internal/udpserver/server_session.go
@@ -70,6 +70,12 @@ func (s *Server) handleSessionCloseNotice(vpnPacket VpnProto.Packet, now time.Ti
 
 	lookup, known := s.sessions.Lookup(vpnPacket.SessionID)
 	if !known || lookup.State != sessionLookupActive || lookup.Cookie != vpnPacket.SessionCookie {
+		if s.debugLoggingEnabled() {
+			s.log.Debugf(
+				"\U0001F6AA <yellow>Session close rejected <magenta>|</magenta> Session: <cyan>%d</cyan> <magenta>|</magenta> Known: <cyan>%t</cyan> <magenta>|</magenta> Cookie match: <cyan>%t</cyan></yellow>",
+				vpnPacket.SessionID, known, known && lookup.Cookie == vpnPacket.SessionCookie,
+			)
+		}
 		return
 	}
 

--- a/internal/udpserver/server_utils.go
+++ b/internal/udpserver/server_utils.go
@@ -45,10 +45,16 @@ func buildNoDataResponseLite(packet []byte, parsed DnsParser.LitePacket) []byte 
 }
 
 func (s *Server) buildNoDataResponseLogged(packet []byte, reason string) []byte {
+	if s.debugLoggingEnabled() {
+		s.log.Debugf("⚠️ <yellow>NoData response <magenta>|</magenta> Reason: <cyan>%s</cyan></yellow>", reason)
+	}
 	return buildNoDataResponse(packet)
 }
 
 func (s *Server) buildNoDataResponseLiteLogged(packet []byte, parsed DnsParser.LitePacket, reason string) []byte {
+	if s.debugLoggingEnabled() {
+		s.log.Debugf("⚠️ <yellow>NoData response <magenta>|</magenta> Reason: <cyan>%s</cyan></yellow>", reason)
+	}
 	return buildNoDataResponseLite(packet, parsed)
 }
 

--- a/internal/udpserver/stream_server.go
+++ b/internal/udpserver/stream_server.go
@@ -59,6 +59,14 @@ func NewStreamServer(streamID uint16, sessionID uint8, arqConfig arq.Config, loc
 
 	s.ARQ = arq.NewARQ(streamID, sessionID, s, localConn, mtu, logger, arqConfig)
 	s.ARQ.Start()
+
+	if logger != nil {
+		logger.Debugf(
+			"🧦 <green>Stream Server Created <magenta>|</magenta> Stream: <cyan>%d</cyan> <magenta>|</magenta> Session: <cyan>%d</cyan></green>",
+			streamID, sessionID,
+		)
+	}
+
 	return s
 }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                              
  
  This PR adds comprehensive, structured logging throughout the VPN system to improve operational observability and debugging.                                                                                                                                            
                                                            
  ### Logger Enhancement                                                                                                                                                                                                                                                  
  - Added `SubLogger` type with `With(key, value)` chaining for automatic context propagation (e.g., `[Sess:3] [Str:42]`)
  - Added `Warnf` to the ARQ `Logger` interface                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                          
  ### Session Lifecycle Logging                                                                                                                                                                                                                                           
  - Log session accepted with ID, cookie, and compression mode (INFO)                                                                                                                                                                                                     
  - Log session init failures, server busy, query build errors (WARN/DEBUG)                                                                                                                                                                                               
  - Log rejected session close notices on server side (DEBUG)                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                          
  ### Stream Lifecycle Logging                                                                                                                                                                                                                                            
  - Log stream creation with stream/session IDs (INFO)                                                                                                                                                                                                                    
  - Log stream cleanup (DEBUG) and bulk close with count (INFO)                                                                                                                                                                                                           
  - Log server-side stream creation (DEBUG)                                                                                                                                                                                                                               
  - Elevated SOCKS connected to INFO, added SOCKS failure logging (WARN)                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                          
  ### Silent Error Elimination                                                                                                                                                                                                                                            
  - DNS response write failures in `dns_listener.go` (WARN)                                                                                                                                                                                                               
  - SOCKS handshake errors and unknown versions (DEBUG)                                                                                                                                                                                                                   
  - Dispatcher encode/build failures (DEBUG) and no-valid-connections (WARN)                                                                                                                                                                                              
  - Session close query build failures (DEBUG)                                                                                                                                                                                                                            
  - Server `buildNoDataResponseLogged` now actually logs the reason (DEBUG)                                                                                                                                                                                               
                                                                                                                                                                                                                                                                          
  ### Periodic Stats Reporting                              
  - Client: 30s ticker logging active/pending/draining streams, valid resolvers, and per-resolver sent/acked/loss%/RTT                                                                                                                                                    
  - Server: 30s ticker logging active sessions and total streams                                                                                                                                                                                                          
  - Added `Balancer.Stats()` method for aggregate connection statistics                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                          
  ### ARQ Logging                                                                                                                                                                                                                                                         
  - Data retransmissions with sequence number (DEBUG)                                                                                                                                                                                                                     
  - Max retransmissions exceeded (WARN)                                                                                                                                                                                                                                   
  - Inactivity timeout with idle duration (INFO)
  - Control packet expiry and retransmissions (DEBUG)                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                          
  ## Design Decisions                                                                                                                                                                                                                                                     
  - No external dependencies added — extends the existing custom logger                                                                                                                                                                                                   
  - No per-packet logging in hot paths to avoid performance impact                                                                                                                                                                                                        
  - Keeps the project's emoji/color tag style                                                                                                                                                                                                                             
  - `SubLogger` satisfies the ARQ `Logger` interface for seamless integration                                                                                                                                                                                             
                                                                                                                                                                                                                                                                          
  ## Files Changed (16)                                                                                                                                                                                                                                                   
  - `internal/logger/logger.go` — SubLogger type                                                                                                                                                                                                                          
  - `internal/logger/logger_test.go` — 4 new tests                                                                                                                                                                                                                        
  - `internal/arq/arq.go` — Warnf interface + 5 log points
  - `internal/arq/arq_test.go` — testLogger updated                                                                                                                                                                                                                       
  - `internal/client/session.go` — session lifecycle logs   
  - `internal/client/stream_client.go` — stream lifecycle logs                                                                                                                                                                                                            
  - `internal/client/socks_manager.go` — SOCKS result logs  
  - `internal/client/async_runtime.go` — periodic stats logger                                                                                                                                                                                                            
  - `internal/client/balancer.go` — Stats() method          
  - `internal/client/dispatcher.go` — error path logs                                                                                                                                                                                                                     
  - `internal/client/dns_listener.go` — write error log     
  - `internal/client/tcp_listener.go` — unsupported protocol log                                                                                                                                                                                                          
  - `internal/udpserver/server.go` — server stats logger    
  - `internal/udpserver/server_session.go` — close rejection log                                                                                                                                                                                                          
  - `internal/udpserver/server_utils.go` — NoData reason log                                                                                                                                                                                                              
  - `internal/udpserver/stream_server.go` — stream creation log                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                          
  ## Testing                                                
  - All existing tests pass                                                                                                                                                                                                                                               
  - 4 new logger tests added (prefix, chaining, level filtering, Enabled)
  - `go build ./...` clean 