### PR TITLE
Fix ARQ reset termination logic to only trigger on peer RST

### DIFF
--- a/internal/arq/arq.go
+++ b/internal/arq/arq.go
@@ -1761,8 +1761,13 @@ func (a *ARQ) handleTerminalRetransmitState(now time.Time) bool {
 		return false
 	}
 
-	// Check for peer-signaled reset termination
-	if (a.state == StateReset || a.rstReceived) && !a.closed {
+	// Check for peer-signaled reset termination.
+	// Only trigger on a.rstReceived (peer sent RST to us). Do NOT use
+	// a.state==StateReset here because StateReset is also set by MarkRstSent()
+	// (when WE send RST). That would cause every locally-initiated RST to be
+	// mis-identified as a peer reset, killing the stream immediately before the
+	// RST_ACK arrives.
+	if a.rstReceived && !a.closed {
 		a.mu.Unlock()
 		a.MarkRstReceived()
 		a.Close("Peer reset signaled", CloseOptions{Force: true})


### PR DESCRIPTION
## Summary
Fixed a bug in the ARQ reset termination handling where locally-initiated RST packets were being incorrectly identified as peer-initiated resets, causing streams to close prematurely before the RST_ACK could arrive.

## Key Changes
- Modified the condition in `handleTerminalRetransmitState()` to check only `a.rstReceived` instead of `(a.state == StateReset || a.rstReceived)`
- Removed the `a.state == StateReset` check because `StateReset` is set by both peer-initiated resets AND locally-initiated resets via `MarkRstSent()`
- This prevents locally-initiated RSTs from being misidentified as peer resets and triggering immediate stream closure

## Implementation Details
The bug occurred because `a.state == StateReset` is set in two different scenarios:
1. When the peer sends us a RST packet (peer-initiated reset)
2. When we send a RST packet via `MarkRstSent()` (locally-initiated reset)

By checking only `a.rstReceived`, which is exclusively set when the peer sends us a RST, we now correctly distinguish between the two cases and allow locally-initiated resets to complete their handshake with the RST_ACK before closing the stream.

https://claude.ai/code/session_018wuEb2RZDjqpbT35utEEVm