### PR TITLE
Add SOCKS5 brute-force rate limiter

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -136,6 +136,9 @@ type Client struct {
 	localDNSCacheFlushTick time.Duration
 	localDNSCacheLoadOnce  sync.Once
 	localDNSCacheFlushOnce sync.Once
+
+	// SOCKS5 brute-force rate limiter
+	socksRateLimit *socksRateLimiter
 }
 
 // clientStreamTXPacket represents a queued packet pending transmission or retransmission.
@@ -261,6 +264,7 @@ func New(cfg config.ClientConfig, log *logger.Logger, codec *security.Codec) *Cl
 		localDNSCacheFlushTick: time.Duration(cfg.LocalDNSCacheFlushSec) * time.Second,
 		orphanQueue:            mlq.New[VpnProto.Packet](cfg.OrphanQueueInitialCapacity),
 		sessionResetSignal:     make(chan struct{}, 1),
+		socksRateLimit:         newSocksRateLimiter(),
 	}
 
 	if c.streamResolverFailoverResendThreshold < 1 {

--- a/internal/client/socks_manager.go
+++ b/internal/client/socks_manager.go
@@ -67,6 +67,15 @@ func (c *Client) supportsSOCKS4() bool {
 
 // HandleSOCKS5 manages the local SOCKS handshake and supports SOCKS4/4a and SOCKS5.
 func (c *Client) HandleSOCKS5(ctx context.Context, conn net.Conn) {
+	// Rate-limit check: reject immediately if IP is banned.
+	if c.socksRateLimit != nil {
+		ip := extractIP(conn)
+		if c.socksRateLimit.IsBlocked(ip) {
+			_ = conn.Close()
+			return
+		}
+	}
+
 	version := make([]byte, 1)
 	if _, err := io.ReadFull(conn, version); err != nil {
 		_ = conn.Close()
@@ -150,7 +159,16 @@ func (c *Client) handleSOCKS5Request(ctx context.Context, conn net.Conn) {
 
 		if string(user) != c.cfg.SOCKS5User || string(pass) != c.cfg.SOCKS5Pass {
 			_, _ = conn.Write([]byte{SOCKS5_USER_AUTH_VERSION, SOCKS5_USER_AUTH_FAILURE})
-			c.log.Warnf("🔒 <yellow>SOCKS5 Authentication failed for user: <cyan>%s</cyan></yellow>", string(user))
+			ip := extractIP(conn)
+			banned := false
+			if c.socksRateLimit != nil {
+				banned = c.socksRateLimit.RecordFailure(ip)
+			}
+			if banned {
+				c.log.Warnf("🔒 <red>SOCKS5 brute-force detected from <cyan>%s</cyan>, IP temporarily banned</red>", ip)
+			} else {
+				c.log.Warnf("🔒 <yellow>SOCKS5 Authentication failed for user: <cyan>%s</cyan> from <cyan>%s</cyan></yellow>", string(user), ip)
+			}
 			_ = conn.Close()
 			return
 		}
@@ -252,6 +270,12 @@ func (c *Client) handleSOCKS4Request(ctx context.Context, conn net.Conn) {
 	}
 
 	if c.cfg.SOCKS5Auth && c.cfg.SOCKS5User != string(userID) {
+		if c.socksRateLimit != nil {
+			ip := extractIP(conn)
+			if c.socksRateLimit.RecordFailure(ip) {
+				c.log.Warnf("🔒 <red>SOCKS4 brute-force detected from <cyan>%s</cyan>, IP temporarily banned</red>", ip)
+			}
+		}
 		_ = c.sendSocks4Reply(conn, false)
 		_ = conn.Close()
 		return

--- a/internal/client/socks_ratelimit.go
+++ b/internal/client/socks_ratelimit.go
@@ -1,0 +1,186 @@
+// ==============================================================================
+// MasterDnsVPN
+// Author: MasterkinG32
+// Github: https://github.com/masterking32
+// Year: 2026
+// ==============================================================================
+// Package client provides the core logic for the MasterDnsVPN client.
+// This file (socks_ratelimit.go) implements IP-based rate limiting for SOCKS5
+// authentication failures to mitigate brute-force credential stuffing attacks.
+// ==============================================================================
+package client
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	// socksRateLimitWindow is the sliding window duration for counting auth failures.
+	socksRateLimitWindow = 2 * time.Minute
+
+	// socksRateLimitMaxFailures is the maximum number of auth failures allowed
+	// within the window before the IP is temporarily banned.
+	// Set high enough (10) so a legitimate user who fat-fingers their password
+	// a few times is not affected, while brute-forcers still trigger quickly.
+	socksRateLimitMaxFailures = 10
+
+	// socksRateLimitBaseBan is the ban duration after the *first* threshold breach.
+	// Kept short (1 minute) so an honest user just pauses and rechecks their password.
+	// Subsequent bans double each time (exponential back-off).
+	socksRateLimitBaseBan = 1 * time.Minute
+
+	// socksRateLimitMaxBanDuration caps the maximum ban duration.
+	socksRateLimitMaxBanDuration = 15 * time.Minute
+
+	// socksRateLimitBanDecayAfter resets the escalation counter back to zero
+	// if the IP stays clean for this long after a ban expires.
+	// Forgives legitimate users who fixed their mistake and moved on.
+	socksRateLimitBanDecayAfter = 10 * time.Minute
+
+	// socksRateLimitPurgeInterval controls how often stale entries are cleaned up.
+	socksRateLimitPurgeInterval = 60 * time.Second
+)
+
+type socksAuthFailureRecord struct {
+	timestamps []time.Time
+	banUntil   time.Time
+	banCount   int
+}
+
+type socksRateLimiter struct {
+	mu        sync.Mutex
+	records   map[string]*socksAuthFailureRecord
+	lastPurge time.Time
+}
+
+func newSocksRateLimiter() *socksRateLimiter {
+	return &socksRateLimiter{
+		records:   make(map[string]*socksAuthFailureRecord),
+		lastPurge: time.Now(),
+	}
+}
+
+// extractIP returns the bare IP address string from a net.Conn, stripping the port.
+func extractIP(conn net.Conn) string {
+	if conn == nil {
+		return ""
+	}
+	addr := conn.RemoteAddr()
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+	return host
+}
+
+// IsBlocked returns true if the given IP is currently banned due to excessive
+// authentication failures. Safe for concurrent use.
+func (r *socksRateLimiter) IsBlocked(ip string) bool {
+	if ip == "" {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec, ok := r.records[ip]
+	if !ok {
+		return false
+	}
+	if rec.banUntil.IsZero() {
+		return false
+	}
+	return time.Now().Before(rec.banUntil)
+}
+
+// RecordFailure records an authentication failure for the given IP. If the
+// failure count within the sliding window exceeds the threshold, the IP is
+// banned for an escalating duration.
+// Returns true if the IP is now banned as a result of this failure.
+func (r *socksRateLimiter) RecordFailure(ip string) bool {
+	if ip == "" {
+		return false
+	}
+	now := time.Now()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Periodic cleanup of stale entries.
+	if now.Sub(r.lastPurge) >= socksRateLimitPurgeInterval {
+		r.purgeLocked(now)
+		r.lastPurge = now
+	}
+
+	rec, ok := r.records[ip]
+	if !ok {
+		rec = &socksAuthFailureRecord{}
+		r.records[ip] = rec
+	}
+
+	// If already banned, just extend awareness.
+	if !rec.banUntil.IsZero() && now.Before(rec.banUntil) {
+		return true
+	}
+
+	// Decay escalation if the IP stayed clean long enough after a previous ban.
+	if rec.banCount > 0 && !rec.banUntil.IsZero() && now.After(rec.banUntil) {
+		if now.Sub(rec.banUntil) >= socksRateLimitBanDecayAfter {
+			rec.banCount = 0
+		}
+	}
+
+	// Trim timestamps outside the sliding window.
+	cutoff := now.Add(-socksRateLimitWindow)
+	trimmed := rec.timestamps[:0]
+	for _, ts := range rec.timestamps {
+		if ts.After(cutoff) {
+			trimmed = append(trimmed, ts)
+		}
+	}
+	rec.timestamps = append(trimmed, now)
+
+	if len(rec.timestamps) >= socksRateLimitMaxFailures {
+		rec.banCount++
+		// Exponential back-off: 1m, 2m, 4m, 8m, capped at 15m.
+		banDuration := socksRateLimitBaseBan
+		for i := 1; i < rec.banCount; i++ {
+			banDuration *= 2
+			if banDuration >= socksRateLimitMaxBanDuration {
+				banDuration = socksRateLimitMaxBanDuration
+				break
+			}
+		}
+		rec.banUntil = now.Add(banDuration)
+		rec.timestamps = rec.timestamps[:0] // Reset window after ban.
+		return true
+	}
+	return false
+}
+
+// purgeLocked removes expired records to prevent unbounded memory growth.
+// Must be called with r.mu held.
+func (r *socksRateLimiter) purgeLocked(now time.Time) {
+	cutoff := now.Add(-socksRateLimitWindow)
+	for ip, rec := range r.records {
+		// Remove if not banned and no recent failures.
+		if !rec.banUntil.IsZero() && now.Before(rec.banUntil) {
+			continue
+		}
+		// Check if all timestamps are expired.
+		hasRecent := false
+		for _, ts := range rec.timestamps {
+			if ts.After(cutoff) {
+				hasRecent = true
+				break
+			}
+		}
+		if !hasRecent && (rec.banUntil.IsZero() || now.After(rec.banUntil)) {
+			delete(r.records, ip)
+		}
+	}
+}

--- a/internal/client/socks_ratelimit_test.go
+++ b/internal/client/socks_ratelimit_test.go
@@ -1,0 +1,122 @@
+// ==============================================================================
+// MasterDnsVPN
+// Author: MasterkinG32
+// Github: https://github.com/masterking32
+// Year: 2026
+// ==============================================================================
+package client
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSocksRateLimiterAllowsUnderThreshold(t *testing.T) {
+	rl := newSocksRateLimiter()
+	ip := "192.168.1.100"
+
+	for i := 0; i < socksRateLimitMaxFailures-1; i++ {
+		if rl.RecordFailure(ip) {
+			t.Fatalf("should not ban after %d failures (threshold=%d)", i+1, socksRateLimitMaxFailures)
+		}
+	}
+
+	if rl.IsBlocked(ip) {
+		t.Fatal("should not be blocked under threshold")
+	}
+}
+
+func TestSocksRateLimiterBansAtThreshold(t *testing.T) {
+	rl := newSocksRateLimiter()
+	ip := "10.0.0.1"
+
+	for i := 0; i < socksRateLimitMaxFailures-1; i++ {
+		rl.RecordFailure(ip)
+	}
+
+	banned := rl.RecordFailure(ip)
+	if !banned {
+		t.Fatal("should be banned at threshold")
+	}
+
+	if !rl.IsBlocked(ip) {
+		t.Fatal("should report blocked after ban")
+	}
+}
+
+func TestSocksRateLimiterDifferentIPsIndependent(t *testing.T) {
+	rl := newSocksRateLimiter()
+
+	for i := 0; i < socksRateLimitMaxFailures; i++ {
+		rl.RecordFailure("1.2.3.4")
+	}
+
+	if rl.IsBlocked("5.6.7.8") {
+		t.Fatal("unrelated IP should not be blocked")
+	}
+}
+
+func TestSocksRateLimiterEmptyIPNotBlocked(t *testing.T) {
+	rl := newSocksRateLimiter()
+	if rl.IsBlocked("") {
+		t.Fatal("empty IP should never be blocked")
+	}
+	if rl.RecordFailure("") {
+		t.Fatal("empty IP should never trigger ban")
+	}
+}
+
+func TestSocksRateLimiterBanDecayResetsEscalation(t *testing.T) {
+	rl := newSocksRateLimiter()
+	ip := "10.0.0.50"
+
+	// First ban: banCount becomes 1, ban = 1 minute.
+	for i := 0; i < socksRateLimitMaxFailures; i++ {
+		rl.RecordFailure(ip)
+	}
+	if !rl.IsBlocked(ip) {
+		t.Fatal("should be banned after first threshold breach")
+	}
+
+	// Simulate time passing: ban expired + decay period elapsed.
+	rl.mu.Lock()
+	rec := rl.records[ip]
+	rec.banUntil = time.Now().Add(-(socksRateLimitBanDecayAfter + time.Minute))
+	rl.mu.Unlock()
+
+	// Next threshold breach should be treated as a first offense again (1 min ban).
+	for i := 0; i < socksRateLimitMaxFailures; i++ {
+		rl.RecordFailure(ip)
+	}
+
+	rl.mu.Lock()
+	if rec.banCount != 1 {
+		t.Fatalf("ban count should have decayed and reset to 1, got %d", rec.banCount)
+	}
+	rl.mu.Unlock()
+}
+
+func TestSocksRateLimiterPurgeRemovesStale(t *testing.T) {
+	rl := newSocksRateLimiter()
+	ip := "172.16.0.1"
+
+	// Manually insert an old record.
+	rl.mu.Lock()
+	rl.records[ip] = &socksAuthFailureRecord{
+		timestamps: []time.Time{time.Now().Add(-5 * time.Minute)},
+	}
+	rl.mu.Unlock()
+
+	// Trigger purge.
+	rl.mu.Lock()
+	rl.purgeLocked(time.Now())
+	rl.mu.Unlock()
+
+	rl.mu.Lock()
+	_, exists := rl.records[ip]
+	rl.mu.Unlock()
+
+	if exists {
+		t.Fatal("stale record should have been purged")
+	}
+}


### PR DESCRIPTION
IP-based sliding-window rate limiter for SOCKS5/SOCKS4 auth failures. Designed to block brute-forcers while being forgiving to legitimate users:

- 10 failures within 2 min window triggers a ban
- First ban is only 1 minute (enough to recheck password)
- Exponential escalation: 1m, 2m, 4m, 8m, capped at 15m
- Ban decay: escalation resets after 10 min clean period
- Stale records auto-purged to prevent memory growth

This was made because some users reported bruteforces on socks clients on iran IP. mostly improved by claude opus.