### PR TITLE
Show reachable network IPs when client listens on 0.0.0.0

### DIFF
--- a/internal/client/dns_listener.go
+++ b/internal/client/dns_listener.go
@@ -19,6 +19,7 @@ import (
 	dnsCache "masterdnsvpn-go/internal/dnscache"
 	dnsParser "masterdnsvpn-go/internal/dnsparser"
 	Enums "masterdnsvpn-go/internal/enums"
+	"masterdnsvpn-go/internal/netutil"
 	VpnProto "masterdnsvpn-go/internal/vpnproto"
 )
 
@@ -53,6 +54,9 @@ func (l *DNSListener) Start(ctx context.Context, ip string, port int) error {
 	l.conn = conn
 
 	l.client.log.Infof("🚀 <green>DNS server is listening on <cyan>%s:%d</cyan></green>", ip, port)
+	if hint := netutil.FormatListenHint(ip, port); hint != "" {
+		l.client.log.Infof("🌐 <green>DNS Server %s</green>", hint)
+	}
 
 	go func() {
 		buf := make([]byte, 4096)

--- a/internal/client/tcp_listener.go
+++ b/internal/client/tcp_listener.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"masterdnsvpn-go/internal/netutil"
 )
 
 type TCPListener struct {
@@ -93,6 +95,12 @@ func (l *TCPListener) Start(ctx context.Context, ip string, port int) error {
 				go l.handleConnection(ctx, conn, l.protocolType)
 			}
 		}(listener)
+	}
+
+	if l.client != nil && l.client.log != nil {
+		if hint := netutil.FormatListenHint(ip, port); hint != "" {
+			l.client.log.Infof("🌐 <green>%s Proxy %s</green>", l.protocolType, hint)
+		}
 	}
 
 	return nil

--- a/internal/netutil/localip.go
+++ b/internal/netutil/localip.go
@@ -1,0 +1,103 @@
+// ==============================================================================
+// MasterDnsVPN
+// Author: MasterkinG32
+// Github: https://github.com/masterking32
+// Year: 2026
+// ==============================================================================
+
+package netutil
+
+import (
+	"net"
+	"sort"
+	"strings"
+)
+
+// LocalInterfaceIPs returns the non-loopback unicast IP addresses of the host.
+// It works cross-platform (Windows, Linux, macOS).
+// If the machine has no usable addresses, it returns nil.
+func LocalInterfaceIPs() []string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+
+	var ips []string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+				continue
+			}
+			ips = append(ips, ip.String())
+		}
+	}
+
+	// Sort: IPv4 first, then IPv6.
+	sort.Slice(ips, func(i, j int) bool {
+		iIs4 := !strings.Contains(ips[i], ":")
+		jIs4 := !strings.Contains(ips[j], ":")
+		if iIs4 != jIs4 {
+			return iIs4
+		}
+		return ips[i] < ips[j]
+	})
+	return ips
+}
+
+// FormatListenHint returns a user-friendly string listing the reachable addresses
+// for a listener bound to the given ip and port.
+// If ip is a wildcard (0.0.0.0 or ::), it enumerates host interfaces.
+// Otherwise it returns an empty string (no extra hint needed).
+func FormatListenHint(ip string, port int) string {
+	trimmed := strings.TrimSpace(ip)
+	if trimmed != "0.0.0.0" && trimmed != "::" && trimmed != "" {
+		return ""
+	}
+
+	localIPs := LocalInterfaceIPs()
+	if len(localIPs) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("Reachable at: ")
+	for i, addr := range localIPs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(net.JoinHostPort(addr, itoa(port)))
+	}
+	return b.String()
+}
+
+func itoa(n int) string {
+	// Simple int-to-string without importing strconv.
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + itoa(-n)
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
When the SOCKS/TCP proxy or DNS listener binds to a wildcard address (0.0.0.0 or ::), the client now logs all reachable network IPs so users don't need to run ipconfig/ifconfig to find their address.

Example log output:
  SOCKS5 Proxy server is listening on 0.0.0.0:2080
  SOCKS5 Proxy Reachable at: 192.168.1.103:2080, 10.0.0.5:2080

this would help the clients for less knowledge of network to able to understand more easily about the network IPs