### PR TITLE
Limit capGuess to totalCapacity in deferred_session.go

### DIFF
--- a/internal/udpserver/deferred_session.go
+++ b/internal/udpserver/deferred_session.go
@@ -69,6 +69,11 @@ func deriveDeferredSessionPendingCap(workerCount int, queueLimit int) int32 {
 		capGuess = 8
 	}
 
+	// Never exceed what the worker queues can actually hold.
+	if capGuess > totalCapacity {
+		capGuess = totalCapacity
+	}
+
 	return int32(capGuess)
 }
 


### PR DESCRIPTION
Ensure capGuess does not exceed totalCapacity.