### PR TITLE
refactor(client): enhance client CLI flags and add domain(s) and key

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"masterdnsvpn-go/internal/client"
@@ -28,11 +30,53 @@ func waitForExitInput() {
 	_, _ = reader.ReadString('\n')
 }
 
+func printClientUsage(fs *flag.FlagSet) {
+	bin := filepath.Base(os.Args[0])
+	if bin == "" || bin == "." || strings.Contains(bin, "go-build") || strings.HasPrefix(bin, "main") {
+		bin = "masterdnsvpn-client"
+	}
+
+	fmt.Fprintf(fs.Output(), "MasterDnsVPN Client - A high-performance DNS-based VPN Tunnel\n\n")
+	fmt.Fprintf(fs.Output(), "Usage:\n")
+	fmt.Fprintf(fs.Output(), "  %s [flags]\n\n", bin)
+	fmt.Fprintf(fs.Output(), "Examples:\n")
+	fmt.Fprintf(fs.Output(), "  %s -config client_config.toml\n", bin)
+	fmt.Fprintf(fs.Output(), "  %s -config ./client_config.toml -resolvers ./client_resolvers.txt\n", bin)
+	fmt.Fprintf(fs.Output(), "  %s -log ./client.log -version\n", bin)
+	fmt.Fprintf(fs.Output(), "  %s -config ./client_config.toml -d domain1.com,domain2.com -k my-secret-key\n\n", bin)
+	fmt.Fprintf(fs.Output(), "Flags:\n")
+	fs.PrintDefaults()
+}
+
 func main() {
-	configPath := flag.String("config", "client_config.toml", "Path to client configuration file")
-	logPath := flag.String("log", "", "Path to log file (optional)")
-	resolversPath := flag.String("resolvers", "", "Path to resolver file override (optional)")
-	versionFlag := flag.Bool("version", false, "Print version and exit")
+	flag.CommandLine.SetOutput(os.Stdout)
+	flag.Usage = func() {
+		printClientUsage(flag.CommandLine)
+	}
+
+	var configPath string
+	flag.StringVar(&configPath, "config", "client_config.toml", "Path to client configuration file")
+	flag.StringVar(&configPath, "c", "client_config.toml", "Alias for -config")
+
+	var logPath string
+	flag.StringVar(&logPath, "log", "", "Path to log file (optional)")
+	flag.StringVar(&logPath, "l", "", "Alias for -log")
+
+	var resolversPath string
+	flag.StringVar(&resolversPath, "resolvers", "", "Path to resolver file override (optional)")
+	flag.StringVar(&resolversPath, "r", "", "Alias for -resolvers")
+
+	var showVersion bool
+	flag.BoolVar(&showVersion, "version", false, "Print version and exit")
+	flag.BoolVar(&showVersion, "v", false, "Alias for -version")
+
+	var showHelp bool
+	flag.BoolVar(&showHelp, "help", false, "Show help and exit")
+	flag.BoolVar(&showHelp, "h", false, "Alias for -help")
+
+	domainsShort := flag.String("d", "", "Alias for -domains (comma separated)")
+	keyShort := flag.String("k", "", "Alias for -encryption-key")
+	
 	configFlags, err := config.NewClientConfigFlagBinder(flag.CommandLine)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Client flag setup failed: %v\n", err)
@@ -40,19 +84,37 @@ func main() {
 	}
 	flag.Parse()
 
-	if *versionFlag {
+	if showHelp {
+		flag.Usage()
+		return
+	}
+
+	if flag.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "Unexpected positional arguments: %v\n\n", flag.Args())
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	if showVersion {
 		fmt.Printf("MasterDnsVPN Client Version: %s\n", version.GetVersion())
 		return
 	}
 
-	resolvedConfigPath := runtimepath.Resolve(*configPath)
+	resolvedConfigPath := runtimepath.Resolve(configPath)
 	overrides := configFlags.Overrides()
-	if *resolversPath != "" {
-		resolvedResolversPath := runtimepath.Resolve(*resolversPath)
+	if resolversPath != "" {
+		resolvedResolversPath := runtimepath.Resolve(resolversPath)
 		overrides.ResolversFilePath = &resolvedResolversPath
 	}
+	
+	if *domainsShort != "" {
+		overrides.Values["Domains"] = strings.Split(*domainsShort, ",")
+	}
+	if *keyShort != "" {
+		overrides.Values["EncryptionKey"] = *keyShort
+	}
 
-	app, err := client.Bootstrap(resolvedConfigPath, *logPath, overrides)
+	app, err := client.Bootstrap(resolvedConfigPath, logPath, overrides)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Client startup failed: %v\n", err)
 		waitForExitInput()
@@ -65,7 +127,7 @@ func main() {
 	if log != nil {
 		log.Infof("\U0001F680 <green>MasterDnsVPN Client Started</green>")
 		log.Infof("\U0001F4C4 <green>Configuration loaded from: <cyan>%s</cyan></green>", resolvedConfigPath)
-		log.Infof("\U0001F5C2  <green>Connection Catalog: <cyan>%d</cyan> domain-resolver pairs</green>", app.Balancer().TotalCount())
+		log.Infof("\U0001F5C2  <green>Connection Catalog: <cyan>%d</cyan> domain-resolver pairs</green>", len(app.Connections()))
 	}
 
 	// Wait for termination signal

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -127,7 +127,7 @@ func main() {
 	if log != nil {
 		log.Infof("\U0001F680 <green>MasterDnsVPN Client Started</green>")
 		log.Infof("\U0001F4C4 <green>Configuration loaded from: <cyan>%s</cyan></green>", resolvedConfigPath)
-		log.Infof("\U0001F5C2  <green>Connection Catalog: <cyan>%d</cyan> domain-resolver pairs</green>", len(app.Connections()))
+		log.Infof("\U0001F5C2  <green>Connection Catalog: <cyan>%d</cyan> domain-resolver pairs</green>", app.Balancer().TotalCount())
 	}
 
 	// Wait for termination signal

--- a/cmd/client/versioninfo.json
+++ b/cmd/client/versioninfo.json
@@ -2,13 +2,13 @@
     "FixedFileInfo": {
         "FileVersion": {
             "Major": 1,
-            "Minor": 0,
+            "Minor": 1,
             "Patch": 0,
             "Build": 0
         },
         "ProductVersion": {
             "Major": 1,
-            "Minor": 0,
+            "Minor": 1,
             "Patch": 0,
             "Build": 0
         },
@@ -22,13 +22,13 @@
         "Comments": "MasterDnsVPN Client",
         "CompanyName": "MasterkinG32",
         "FileDescription": "MasterDnsVPN Client",
-        "FileVersion": "1.0.0.0",
+        "FileVersion": "1.1.0.0",
         "InternalName": "MasterDnsVPN_Client",
         "LegalCopyright": "Copyright (c) 2026 MasterkinG32",
         "LegalTrademarks": "",
         "OriginalFilename": "MasterDnsVPN_Client.exe",
         "ProductName": "MasterDnsVPN",
-        "ProductVersion": "1.0.0.0"
+        "ProductVersion": "1.1.0.0"
     },
     "VarFileInfo": {
         "Translation": {


### PR DESCRIPTION
### Refactor: Improve client CLI and add shorthand flags

- Added custom help/usage output with examples
- Introduced shorthand flags (-c, -l, -r, -v, -h)
- Added -d (domains) and -k (encryption key) overrides
- Improved argument validation
- Minor logging improvement (len(app.Connections()))

**No breaking changes. **

🙏 Thanks to @abolix for the help.