### PR TITLE
Feat(Server): Add optional Grafana monitoring dashboard to server installer

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,218 @@
+# MasterDnsVPN Grafana Monitoring
+
+Prometheus + Grafana monitoring for a MasterDnsVPN server running on Linux.
+
+## Overview
+
+```
+MasterDnsVPN Server (UDP :53)
+        │
+        ▼
+iptables byte counters ──┐
+journalctl session logs ─┤
+systemctl service state ─┤
+                         ▼
+              masterdns_exporter.py (:9101)
+                         │
+                         ▼
+                    Prometheus (:9090)
+                         │
+                         ▼
+                   Grafana Dashboard (:3000)
+```
+
+The exporter runs as a systemd service on the same host as MasterDnsVPN. It polls three data sources every 15 seconds and exposes Prometheus metrics at `/metrics`.
+
+## Installation
+
+### Automatic (via main installer)
+
+When running `server_linux_install.sh`, you will be prompted:
+
+```
+>>> Do you want to install Grafana monitoring dashboard? (y/N):
+```
+
+Answering **y** installs everything automatically.
+
+### Automatic (standalone)
+
+If MasterDnsVPN is already installed, run the monitoring installer directly:
+
+```bash
+sudo bash /path/to/masterdnsvpn/monitoring/install.sh
+```
+
+The script auto-detects `INSTALL_DIR`, package manager, and firewall. It will:
+
+1. Install Python 3 and Docker if missing
+2. Add iptables OUTPUT rule for traffic accounting
+3. Deploy and start the exporter as a systemd service
+4. Launch Prometheus + Grafana via Docker Compose
+5. Open firewall ports 3000 and 9090
+
+### Manual Setup
+
+If you prefer to set things up manually, follow the steps below.
+
+#### Prerequisites
+
+- MasterDnsVPN server running as `masterdnsvpn.service`
+- Python 3 installed on the host
+- Docker and Docker Compose
+- `iptables` installed
+
+#### Step 1: iptables Accounting Rules
+
+The exporter reads iptables byte counters. The INPUT rule for `dpt:53` is created by the main installer. You need to add the OUTPUT rule:
+
+```bash
+sudo iptables -I OUTPUT -p udp --sport 53 -j ACCEPT
+sudo iptables-save > /etc/iptables/rules.v4
+```
+
+Verify:
+
+```bash
+sudo iptables -L INPUT -v -n --line-numbers | grep "udp dpt:53"
+sudo iptables -L OUTPUT -v -n --line-numbers | grep "udp spt:53"
+```
+
+#### Step 2: Deploy the Exporter
+
+Create the systemd service:
+
+```bash
+sudo tee /etc/systemd/system/masterdns-exporter.service > /dev/null << 'EOF'
+[Unit]
+Description=MasterDnsVPN Prometheus Exporter
+After=network.target masterdnsvpn.service
+Wants=masterdnsvpn.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /path/to/monitoring/exporters/masterdns_exporter.py
+Restart=always
+RestartSec=5
+Environment=PORT=9101
+Environment=SERVICE_NAME=masterdnsvpn
+Environment=POLL_INTERVAL=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable masterdns-exporter
+sudo systemctl start masterdns-exporter
+```
+
+**Environment variables:**
+
+| Variable        | Default        | Description                            |
+| --------------- | -------------- | -------------------------------------- |
+| `PORT`          | `9101`         | HTTP port for `/metrics` endpoint      |
+| `SERVICE_NAME`  | `masterdnsvpn` | systemd unit name to monitor           |
+| `POLL_INTERVAL` | `15`           | Seconds between data collection cycles |
+
+Verify:
+
+```bash
+curl -s http://127.0.0.1:9101/metrics
+```
+
+#### Step 3: Start Prometheus and Grafana
+
+```bash
+cd /path/to/monitoring
+docker compose up -d
+```
+
+Verify Prometheus target:
+
+```bash
+curl -s http://localhost:9090/api/v1/targets | python3 -c "
+import json,sys
+for t in json.load(sys.stdin)['data']['activeTargets']:
+    if t['labels']['job'] == 'masterdns':
+        print(f\"Health: {t['health']}\")
+"
+```
+
+Open Grafana at `http://<server-ip>:3000` (default credentials: `admin` / `admin`).
+
+The MasterDnsVPN dashboard is auto-provisioned and ready to use.
+
+## Metrics Reference
+
+| Metric                             | Type    | Description                                 |
+| ---------------------------------- | ------- | ------------------------------------------- |
+| `masterdns_server_up`              | gauge   | 1 if systemd service is active, 0 otherwise |
+| `masterdns_server_uptime_seconds`  | gauge   | Server uptime in seconds                    |
+| `masterdns_sessions_alive`         | gauge   | Currently alive tunnel sessions             |
+| `masterdns_sessions_created_total` | counter | Total sessions created since boot           |
+| `masterdns_rx_bytes_total`         | counter | Total bytes received (UDP dpt:53)           |
+| `masterdns_tx_bytes_total`         | counter | Total bytes transmitted (UDP spt:53)        |
+| `masterdns_exporter_up`            | gauge   | 1 if exporter is running                    |
+
+## Dashboard Panels
+
+| Panel                    | Type       | Query                                                                         |
+| ------------------------ | ---------- | ----------------------------------------------------------------------------- |
+| Server Status            | stat       | `masterdns_server_up` with value mappings (0=DOWN, 1=UP)                      |
+| Active Sessions          | stat       | `masterdns_sessions_alive`                                                    |
+| Traffic (Selected Range) | stat       | `increase(rx[$__range]) + increase(tx[$__range])`                             |
+| Traffic (Today)          | stat       | Same as above with `timeFrom: now/d`                                          |
+| Throughput               | timeseries | `rate(masterdns_rx_bytes_total[2m])` and `rate(masterdns_tx_bytes_total[2m])` |
+| Sessions Over Time       | timeseries | `masterdns_sessions_alive` (step-after)                                       |
+
+## Uninstall
+
+```bash
+# Stop and remove containers
+docker compose -f /path/to/monitoring/docker-compose.yml down -v
+
+# Stop and remove exporter
+sudo systemctl stop masterdns-exporter
+sudo systemctl disable masterdns-exporter
+sudo rm /etc/systemd/system/masterdns-exporter.service
+sudo systemctl daemon-reload
+
+# Remove iptables OUTPUT rule (optional)
+sudo iptables -D OUTPUT -p udp --sport 53 -j ACCEPT
+```
+
+Deleting the `monitoring/` directory has zero impact on MasterDnsVPN itself.
+
+## Troubleshooting
+
+```bash
+# Check exporter service
+sudo systemctl status masterdns-exporter
+
+# View exporter logs
+sudo journalctl -u masterdns-exporter -f
+
+# Check iptables counters are incrementing
+sudo iptables -L INPUT -v -n -x | grep "dpt:53"
+sudo iptables -L OUTPUT -v -n -x | grep "spt:53"
+
+# Verify Prometheus can reach the exporter
+curl -s http://127.0.0.1:9101/metrics | head -5
+
+# Check container status
+docker compose -f /path/to/monitoring/docker-compose.yml ps
+
+# Test a Prometheus query
+curl -s 'http://localhost:9090/api/v1/query?query=masterdns_server_up'
+```
+
+### Common Issues
+
+| Problem                  | Cause                                           | Fix                                                                        |
+| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| `rx_bytes = 0`           | iptables rule for `dpt:53` not first match      | Move the UDP 53 rule above any other matching rules                        |
+| Prometheus target `down` | Firewall blocking port 9101 from Docker network | Add `extra_hosts` to Docker Compose or allow port in firewall              |
+| Sessions always 0        | Wrong `SERVICE_NAME` env var                    | Set it to match your systemd unit (e.g. `masterdnsvpn`)                    |
+| Uptime always 0          | `systemctl show` timestamp format mismatch      | Check `systemctl show masterdnsvpn --property=ActiveEnterTimestamp` output |
+| Grafana shows "No data"  | Prometheus not scraping                         | Check Prometheus targets page at `http://<ip>:9090/targets`                |

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: masterdns-prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=30d"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: masterdns-grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/exporters/masterdns_exporter.py
+++ b/monitoring/exporters/masterdns_exporter.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""MasterDnsVPN Prometheus Exporter
+
+Collects metrics from systemctl, iptables, and journalctl and exposes them
+on an HTTP /metrics endpoint in Prometheus exposition format.
+
+No external dependencies -- stdlib only.
+"""
+
+import os
+import re
+import subprocess
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+PORT = int(os.environ.get("PORT", "9101"))
+SERVICE_NAME = os.environ.get("SERVICE_NAME", "masterdnsvpn")
+POLL_INTERVAL = int(os.environ.get("POLL_INTERVAL", "15"))
+
+_metrics_lock = threading.Lock()
+_metrics: dict[str, float] = {
+    "masterdns_server_up": 0,
+    "masterdns_server_uptime_seconds": 0,
+    "masterdns_sessions_alive": 0,
+    "masterdns_sessions_created_total": 0,
+    "masterdns_rx_bytes_total": 0,
+    "masterdns_tx_bytes_total": 0,
+    "masterdns_exporter_up": 1,
+}
+
+METRIC_META = {
+    "masterdns_server_up": ("gauge", "MasterDnsVPN server systemd service is active"),
+    "masterdns_server_uptime_seconds": ("gauge", "MasterDnsVPN server uptime in seconds"),
+    "masterdns_sessions_alive": ("gauge", "Currently alive tunnel sessions"),
+    "masterdns_sessions_created_total": ("counter", "Total sessions created since boot"),
+    "masterdns_rx_bytes_total": ("counter", "Bytes received on UDP port 53 (client to server)"),
+    "masterdns_tx_bytes_total": ("counter", "Bytes transmitted on UDP port 53 (server to client)"),
+    "masterdns_exporter_up": ("gauge", "Exporter is running"),
+}
+
+RENDER_ORDER = [
+    "masterdns_server_up",
+    "masterdns_server_uptime_seconds",
+    "masterdns_sessions_alive",
+    "masterdns_sessions_created_total",
+    "masterdns_rx_bytes_total",
+    "masterdns_tx_bytes_total",
+    "masterdns_exporter_up",
+]
+
+
+def _run(cmd: list[str], timeout: int = 10) -> str:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.stdout
+    except Exception:
+        return ""
+
+
+def collect_service_state() -> tuple[float, float]:
+    """Return (up, uptime_seconds) for the monitored systemd service."""
+    out = _run(["systemctl", "is-active", SERVICE_NAME])
+    if out.strip() != "active":
+        return 0.0, 0.0
+
+    ts_out = _run([
+        "systemctl", "show", SERVICE_NAME, "--property=ActiveEnterTimestamp",
+    ])
+    match = re.search(r"ActiveEnterTimestamp=(.+)", ts_out)
+    if not match:
+        return 1.0, 0.0
+
+    raw = match.group(1).strip()
+    if not raw:
+        return 1.0, 0.0
+
+    try:
+        dt = datetime.strptime(raw, "%a %Y-%m-%d %H:%M:%S %Z")
+        dt = dt.replace(tzinfo=timezone.utc)
+        uptime = max(0.0, (datetime.now(timezone.utc) - dt).total_seconds())
+    except ValueError:
+        uptime = 0.0
+
+    return 1.0, uptime
+
+
+def _parse_iptables_bytes(chain: str, pattern: str) -> float:
+    """Parse exact byte count from iptables -L <chain> -v -n -x."""
+    out = _run(["iptables", "-L", chain, "-v", "-n", "-x"])
+    for line in out.splitlines():
+        if pattern in line:
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    return float(parts[1])
+                except ValueError:
+                    pass
+    return 0.0
+
+
+def collect_traffic() -> tuple[float, float]:
+    rx = _parse_iptables_bytes("INPUT", "dpt:53")
+    tx = _parse_iptables_bytes("OUTPUT", "spt:53")
+    return rx, tx
+
+
+def collect_sessions() -> tuple[float, float]:
+    """Parse journalctl for session created/closed/expired events.
+
+    Returns (alive, total_created).
+    """
+    out = _run([
+        "journalctl", "-u", SERVICE_NAME,
+        "--no-pager", "-o", "short",
+        "--boot",
+    ], timeout=15)
+
+    created = 0
+    closed = 0
+    for line in out.splitlines():
+        if "Session Created" in line:
+            created += 1
+        elif "Session Closed By Client" in line:
+            closed += 1
+        elif "Expired Sessions Cleaned" in line:
+            match = re.search(r"Count:\s*(\d+)", line)
+            if match:
+                closed += int(match.group(1))
+
+    alive = max(0, created - closed)
+    return float(alive), float(created)
+
+
+def poll_loop() -> None:
+    while True:
+        try:
+            up, uptime = collect_service_state()
+            rx, tx = collect_traffic()
+            alive, total = collect_sessions()
+
+            with _metrics_lock:
+                _metrics["masterdns_server_up"] = up
+                _metrics["masterdns_server_uptime_seconds"] = uptime
+                _metrics["masterdns_rx_bytes_total"] = rx
+                _metrics["masterdns_tx_bytes_total"] = tx
+                _metrics["masterdns_sessions_alive"] = alive
+                _metrics["masterdns_sessions_created_total"] = total
+                _metrics["masterdns_exporter_up"] = 1
+        except Exception as exc:
+            print(f"[exporter] collection error: {exc}")
+
+        time.sleep(POLL_INTERVAL)
+
+
+def render_metrics() -> str:
+    with _metrics_lock:
+        snapshot = dict(_metrics)
+
+    lines: list[str] = []
+    for name in RENDER_ORDER:
+        mtype, mhelp = METRIC_META[name]
+        value = snapshot.get(name, 0)
+        lines.append(f"# HELP {name} {mhelp}")
+        lines.append(f"# TYPE {name} {mtype}")
+        if value == int(value):
+            lines.append(f"{name} {int(value)}")
+        else:
+            lines.append(f"{name} {value}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/metrics":
+            body = render_metrics().encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+def main() -> None:
+    print(f"[exporter] starting on :{PORT}, service={SERVICE_NAME}, poll={POLL_INTERVAL}s")
+
+    collector = threading.Thread(target=poll_loop, daemon=True)
+    collector.start()
+
+    server = HTTPServer(("0.0.0.0", PORT), MetricsHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/grafana/dashboards/masterdns.json
+++ b/monitoring/grafana/dashboards/masterdns.json
@@ -1,0 +1,274 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Server Status",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "masterdns_server_up{job=\"masterdns\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": { "text": "DOWN", "color": "red", "index": 0 }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": { "text": "UP", "color": "green", "index": 1 }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Active Sessions",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "masterdns_sessions_alive{job=\"masterdns\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 3,
+      "title": "Traffic (Selected Range)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "increase(masterdns_rx_bytes_total{job=\"masterdns\"}[$__range]) + increase(masterdns_tx_bytes_total{job=\"masterdns\"}[$__range])",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "purple", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Traffic (Today)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "increase(masterdns_rx_bytes_total{job=\"masterdns\"}[$__range]) + increase(masterdns_tx_bytes_total{job=\"masterdns\"}[$__range])",
+          "legendFormat": "Today",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "now/d",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "orange", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(masterdns_rx_bytes_total{job=\"masterdns\"}[2m])",
+          "legendFormat": "Download (client → server)",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(masterdns_tx_bytes_total{job=\"masterdns\"}[2m])",
+          "legendFormat": "Upload (server → client)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Sessions Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "masterdns_sessions_alive{job=\"masterdns\"}",
+          "legendFormat": "Alive Sessions",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "stacking": { "mode": "none" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "fixed", "fixedColor": "blue" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "tags": ["masterdnsvpn", "monitoring"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MasterDnsVPN",
+  "uid": "masterdnsvpn-overview",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: MasterDnsVPN
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/install.sh
+++ b/monitoring/install.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# ============================================================================
+# MasterDnsVPN Monitoring Installer (self-contained)
+#
+# Can be run in two ways:
+#   1. Sourced by server_linux_install.sh  (inherits INSTALL_DIR, PM, etc.)
+#   2. Standalone:  sudo bash monitoring/install.sh
+#
+# Flags:
+#   --yes   Skip the interactive prompt and install monitoring
+# ============================================================================
+
+_MON_AUTO_YES="${_MON_AUTO_YES:-0}"
+for _mon_arg in "$@"; do
+  case "$_mon_arg" in
+    --yes|-y) _MON_AUTO_YES=1 ;;
+  esac
+done
+
+# ------------------------------------------------------------------
+# Logging helpers -- define only if not already provided by the caller
+# ------------------------------------------------------------------
+if ! declare -f log_header >/dev/null 2>&1; then
+  _RED='\033[1;31m'; _GREEN='\033[1;32m'; _YELLOW='\033[1;33m'
+  _BLUE='\033[1;34m'; _CYAN='\033[1;36m'; _BOLD='\033[1m'; _NC='\033[0m'
+  log_header()  { echo -e "\n${_CYAN}${_BOLD}>>> $1${_NC}"; }
+  log_info()    { echo -e "${_BLUE}[INFO]${_NC} $1"; }
+  log_success() { echo -e "${_GREEN}[DONE]${_NC} $1"; }
+  log_warn()    { echo -e "${_YELLOW}[WARN]${_NC} $1"; }
+  log_error()   { echo -e "${_RED}[ERROR]${_NC} $1"; return 1; }
+fi
+
+# ------------------------------------------------------------------
+# Auto-detect variables when running standalone
+# ------------------------------------------------------------------
+if [[ -z "${INSTALL_DIR:-}" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
+fi
+
+if [[ -z "${PM:-}" ]]; then
+  if command -v apt-get >/dev/null 2>&1; then PM="apt";
+  elif command -v dnf >/dev/null 2>&1;     then PM="dnf";
+  elif command -v yum >/dev/null 2>&1;     then PM="yum";
+  else PM=""; fi
+fi
+
+if [[ -z "${ACTIVE_FIREWALL:-}" ]]; then
+  ACTIVE_FIREWALL="none"
+  if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -qw active; then
+    ACTIVE_FIREWALL="ufw"
+  elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+    ACTIVE_FIREWALL="firewalld"
+  elif command -v iptables >/dev/null 2>&1; then
+    ACTIVE_FIREWALL="iptables"
+  elif command -v nft >/dev/null 2>&1; then
+    ACTIVE_FIREWALL="nftables"
+  fi
+fi
+
+MON_DIR="$INSTALL_DIR/monitoring"
+
+# ------------------------------------------------------------------
+# Prompt
+# ------------------------------------------------------------------
+if [[ "${_MON_AUTO_YES:-0}" == "1" ]]; then
+  log_info "Setting up Prometheus exporter, Prometheus, and Grafana dashboard..."
+  INSTALL_MONITORING="y"
+else
+  log_header "Grafana Monitoring (Optional)"
+  INSTALL_MONITORING=""
+  if (echo < /dev/tty) 2>/dev/null; then
+    read -r -p ">>> Do you want to install Grafana monitoring dashboard? (y/N): " INSTALL_MONITORING </dev/tty || INSTALL_MONITORING=""
+  fi
+fi
+
+case "${INSTALL_MONITORING:-}" in
+  [yY]|[yY][eE][sS]) ;;
+  *)
+    log_info "Skipping monitoring installation."
+    return 0 2>/dev/null || exit 0
+    ;;
+esac
+
+# ------------------------------------------------------------------
+# 1. Python 3
+# ------------------------------------------------------------------
+log_header "Installing Monitoring Dependencies"
+if ! command -v python3 >/dev/null 2>&1; then
+  log_info "Installing Python 3..."
+  case "$PM" in
+    apt) apt-get update -y >/dev/null 2>&1 && apt-get install -y python3 >/dev/null 2>&1 ;;
+    dnf) dnf -y install python3 >/dev/null 2>&1 ;;
+    yum) yum -y install python3 >/dev/null 2>&1 ;;
+    *)   log_warn "No package manager found. Install Python 3 manually." ;;
+  esac
+fi
+if command -v python3 >/dev/null 2>&1; then
+  log_success "Python 3 is available: $(python3 --version 2>&1)"
+else
+  log_warn "Python 3 could not be installed. Exporter will not work."
+fi
+
+# ------------------------------------------------------------------
+# 2. Docker & Docker Compose
+# ------------------------------------------------------------------
+install_docker() {
+  log_info "Installing Docker..."
+  case "$PM" in
+    apt)
+      apt-get update -y >/dev/null 2>&1
+      apt-get install -y docker.io docker-compose-plugin >/dev/null 2>&1 \
+        || apt-get install -y docker.io docker-compose >/dev/null 2>&1 \
+        || true
+      ;;
+    dnf)
+      dnf -y install docker docker-compose-plugin >/dev/null 2>&1 || true
+      ;;
+    yum)
+      yum -y install docker docker-compose-plugin >/dev/null 2>&1 || true
+      ;;
+  esac
+
+  if ! command -v docker >/dev/null 2>&1; then
+    log_info "Package manager install failed, trying get.docker.com..."
+    curl -fsSL https://get.docker.com | sh >/dev/null 2>&1 || true
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    systemctl enable docker >/dev/null 2>&1 || true
+    systemctl start docker >/dev/null 2>&1 || true
+  fi
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  install_docker
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  log_success "Docker is available: $(docker --version 2>&1)"
+else
+  log_warn "Docker could not be installed. Prometheus/Grafana containers will not start."
+fi
+
+docker_compose_cmd=""
+if docker compose version >/dev/null 2>&1; then
+  docker_compose_cmd="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  docker_compose_cmd="docker-compose"
+fi
+
+if [[ -z "$docker_compose_cmd" ]]; then
+  log_warn "Docker Compose not found. Trying to install standalone plugin..."
+  mkdir -p /usr/local/lib/docker/cli-plugins 2>/dev/null || true
+  COMPOSE_ARCH="$(uname -m)"
+  case "$COMPOSE_ARCH" in
+    x86_64|amd64) COMPOSE_ARCH="x86_64" ;;
+    aarch64|arm64) COMPOSE_ARCH="aarch64" ;;
+  esac
+  curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${COMPOSE_ARCH}" \
+    -o /usr/local/lib/docker/cli-plugins/docker-compose 2>/dev/null || true
+  chmod +x /usr/local/lib/docker/cli-plugins/docker-compose 2>/dev/null || true
+  if docker compose version >/dev/null 2>&1; then
+    docker_compose_cmd="docker compose"
+    log_success "Docker Compose plugin installed."
+  else
+    log_warn "Docker Compose could not be installed."
+  fi
+fi
+
+# ------------------------------------------------------------------
+# 3. iptables OUTPUT rule for traffic accounting
+# ------------------------------------------------------------------
+log_header "Configuring Traffic Accounting"
+if command -v iptables >/dev/null 2>&1; then
+  iptables -C OUTPUT -p udp --sport 53 -j ACCEPT 2>/dev/null \
+    || iptables -I OUTPUT -p udp --sport 53 -j ACCEPT 2>/dev/null || true
+
+  if command -v netfilter-persistent >/dev/null 2>&1; then
+    netfilter-persistent save >/dev/null 2>&1 || true
+  elif command -v iptables-save >/dev/null 2>&1 && [[ -d /etc/iptables ]]; then
+    iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
+  fi
+  log_success "iptables OUTPUT rule for UDP sport 53 is in place."
+else
+  log_warn "iptables not found. Traffic byte counters will read zero."
+fi
+
+# ------------------------------------------------------------------
+# 4. Deploy exporter
+# ------------------------------------------------------------------
+log_header "Deploying Prometheus Exporter"
+mkdir -p "$INSTALL_DIR/monitoring/exporters" 2>/dev/null || true
+
+if [[ -f "$MON_DIR/exporters/masterdns_exporter.py" ]]; then
+  log_success "Exporter script already at $MON_DIR/exporters/masterdns_exporter.py"
+else
+  log_warn "Exporter script not found at $MON_DIR/exporters/masterdns_exporter.py"
+  log_warn "Ensure the monitoring/ directory from the repo is present in $INSTALL_DIR."
+fi
+
+# ------------------------------------------------------------------
+# 5. systemd unit for exporter
+# ------------------------------------------------------------------
+log_header "Creating Exporter Service"
+cat > /etc/systemd/system/masterdns-exporter.service <<EOF
+[Unit]
+Description=MasterDnsVPN Prometheus Exporter
+After=network.target masterdnsvpn.service
+Wants=masterdnsvpn.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 $MON_DIR/exporters/masterdns_exporter.py
+Restart=always
+RestartSec=5
+Environment=PORT=9101
+Environment=SERVICE_NAME=masterdnsvpn
+Environment=POLL_INTERVAL=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable masterdns-exporter >/dev/null 2>&1
+systemctl restart masterdns-exporter
+
+sleep 2
+if systemctl is-active --quiet masterdns-exporter; then
+  log_success "Exporter service is running on port 9101."
+else
+  log_warn "Exporter service failed to start. Check: journalctl -u masterdns-exporter -f"
+fi
+
+# ------------------------------------------------------------------
+# 6. Verify exporter endpoint
+# ------------------------------------------------------------------
+EXPORTER_CHECK="$(curl -s --max-time 5 http://127.0.0.1:9101/metrics 2>/dev/null | head -1 || true)"
+if [[ -n "$EXPORTER_CHECK" ]]; then
+  log_success "Exporter /metrics endpoint is reachable."
+else
+  log_warn "Could not reach http://127.0.0.1:9101/metrics -- exporter may need a moment to start."
+fi
+
+# ------------------------------------------------------------------
+# 7. Start Prometheus + Grafana containers
+# ------------------------------------------------------------------
+log_header "Starting Prometheus & Grafana"
+if [[ -n "$docker_compose_cmd" && -f "$MON_DIR/docker-compose.yml" ]]; then
+  $docker_compose_cmd -f "$MON_DIR/docker-compose.yml" up -d 2>&1 | tail -5 || true
+  log_success "Monitoring containers started."
+else
+  log_warn "Skipping container launch (Docker Compose or docker-compose.yml not available)."
+fi
+
+# ------------------------------------------------------------------
+# 8. Open firewall ports (3000 Grafana, 9090 Prometheus)
+# ------------------------------------------------------------------
+log_header "Opening Monitoring Firewall Ports"
+case "$ACTIVE_FIREWALL" in
+  ufw)
+    ufw allow 3000/tcp >/dev/null 2>&1 || true
+    ufw allow 9090/tcp >/dev/null 2>&1 || true
+    log_success "Ports 3000, 9090 opened via UFW."
+    ;;
+  firewalld)
+    firewall-cmd --permanent --add-port=3000/tcp >/dev/null 2>&1 || true
+    firewall-cmd --permanent --add-port=9090/tcp >/dev/null 2>&1 || true
+    firewall-cmd --reload >/dev/null 2>&1 || true
+    log_success "Ports 3000, 9090 opened via firewalld."
+    ;;
+  iptables)
+    iptables -C INPUT -p tcp --dport 3000 -j ACCEPT 2>/dev/null || iptables -I INPUT -p tcp --dport 3000 -j ACCEPT 2>/dev/null || true
+    iptables -C INPUT -p tcp --dport 9090 -j ACCEPT 2>/dev/null || iptables -I INPUT -p tcp --dport 9090 -j ACCEPT 2>/dev/null || true
+    if command -v netfilter-persistent >/dev/null 2>&1; then
+      netfilter-persistent save >/dev/null 2>&1 || true
+    elif command -v iptables-save >/dev/null 2>&1 && [[ -d /etc/iptables ]]; then
+      iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
+    fi
+    log_success "Ports 3000, 9090 opened via iptables."
+    ;;
+  nftables)
+    if nft list table inet filter >/dev/null 2>&1; then
+      nft add rule inet filter input tcp dport 3000 accept >/dev/null 2>&1 || true
+      nft add rule inet filter input tcp dport 9090 accept >/dev/null 2>&1 || true
+      log_success "Ports 3000, 9090 opened via nftables."
+    else
+      log_warn "nftables inet filter table not found. Open ports 3000/9090 manually if needed."
+    fi
+    ;;
+  *)
+    log_warn "No firewall detected. Ensure ports 3000 and 9090 are accessible."
+    ;;
+esac
+
+# ------------------------------------------------------------------
+# 9. Print access info
+# ------------------------------------------------------------------
+log_success "Grafana monitoring is ready."
+_MON_INSTALLED=1
+_MON_SERVER_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+[[ -z "$_MON_SERVER_IP" ]] && _MON_SERVER_IP="<your-server-ip>" || true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: masterdns
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ["host.docker.internal:9101"]

--- a/server_linux_install.sh
+++ b/server_linux_install.sh
@@ -20,7 +20,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 require_cmd() { command -v "$1" >/dev/null 2>&1 || log_error "Missing command: $1"; }
 backup_file_once() {
   local f="$1"
-  [[ -f "$f" && ! -f "${f}.bak" ]] && cp -a "$f" "${f}.bak"
+  [[ -f "$f" && ! -f "${f}.bak" ]] && cp -a "$f" "${f}.bak" || true
 }
 extract_config_version() {
   local f="$1"
@@ -122,6 +122,15 @@ echo " | |  | | (_| \__ \ ||  __/ |   | |__| | |\  |____) |"
 echo " |_|  |_|\__,_|___/\__\___|_|   |_____/|_| \_|_____/ "
 echo -e "           MasterDnsVPN Server Auto-Installer${NC}"
 echo -e "${CYAN}------------------------------------------------------${NC}"
+
+_WANT_MONITORING=""
+if (echo < /dev/tty) 2>/dev/null; then
+  read -r -p ">>> Do you want to install Grafana monitoring dashboard? (y/N): " _WANT_MONITORING </dev/tty || _WANT_MONITORING=""
+fi
+case "${_WANT_MONITORING:-}" in
+  [yY]|[yY][eE][sS]) _WANT_MONITORING="y" ;;
+  *) _WANT_MONITORING="n" ;;
+esac
 
 TMP_LOG="init_logs.tmp"
 DOWNLOAD_DIR=""
@@ -593,14 +602,49 @@ fi
 
 log_success "MasterDnsVPN service is running."
 
+if [[ "$_WANT_MONITORING" == "y" ]]; then
+  log_header "Installing Grafana Monitoring"
+  if [[ ! -f "$INSTALL_DIR/monitoring/install.sh" ]]; then
+    _MON_BRANCH="feature/grafana-monitoring"
+    _MON_REPO="https://github.com/Isusami/MasterDnsVPN.git"
+    log_info "Downloading monitoring module from repository..."
+    _MON_TMP="$(mktemp -d /tmp/masterdns_mon.XXXXXX 2>/dev/null || mktemp -d)"
+    if git clone --depth 1 --branch "$_MON_BRANCH" --single-branch "$_MON_REPO" "$_MON_TMP" 2>&1 | tail -1; then
+      if [[ -d "$_MON_TMP/monitoring" ]]; then
+        cp -r "$_MON_TMP/monitoring" "$INSTALL_DIR/monitoring"
+        chmod +x "$INSTALL_DIR/monitoring/install.sh" 2>/dev/null || true
+        log_success "Monitoring module downloaded."
+      else
+        log_warn "Monitoring directory not found in repository."
+      fi
+    else
+      log_warn "Could not download monitoring module. You can install it later from the repo."
+    fi
+    rm -rf "$_MON_TMP" 2>/dev/null || true
+  fi
+  if [[ -f "$INSTALL_DIR/monitoring/install.sh" ]]; then
+    _MON_AUTO_YES=1
+    source "$INSTALL_DIR/monitoring/install.sh"
+  fi
+fi
+
 echo -e "\n${CYAN}======================================================${NC}"
 echo -e " ${GREEN}${BOLD}       INSTALLATION COMPLETED SUCCESSFULLY!${NC}"
 echo -e "${CYAN}======================================================${NC}"
-echo -e "${BOLD}Commands:${NC}"
+echo -e "${BOLD}MasterDnsVPN:${NC}"
 echo -e "  ${YELLOW}>${NC} Start:   systemctl start masterdnsvpn"
 echo -e "  ${YELLOW}>${NC} Stop:    systemctl stop masterdnsvpn"
 echo -e "  ${YELLOW}>${NC} Restart: systemctl restart masterdnsvpn"
 echo -e "  ${YELLOW}>${NC} Logs:    journalctl -u masterdnsvpn -f"
+if [[ "${_MON_INSTALLED:-0}" == "1" ]]; then
+echo -e "\n${BOLD}Grafana:${NC}"
+echo -e "  ${YELLOW}>${NC} URL:      http://${_MON_SERVER_IP}:3000"
+echo -e "  ${YELLOW}>${NC} User:     admin"
+echo -e "  ${YELLOW}>${NC} Password: admin"
+echo -e "${BOLD}Monitoring:${NC}"
+echo -e "  ${YELLOW}>${NC} Restart:  docker compose -f $INSTALL_DIR/monitoring/docker-compose.yml restart"
+echo -e "  ${YELLOW}>${NC} Stop:     docker compose -f $INSTALL_DIR/monitoring/docker-compose.yml down"
+fi
 echo -e "\n${BOLD}Files:${NC}"
 echo -e "  ${YELLOW}>${NC} ${INSTALL_DIR}/server_config.toml"
 echo -e "  ${YELLOW}>${NC} ${INSTALL_DIR}/encrypt_key.txt"


### PR DESCRIPTION
## Summary

Adds an optional Prometheus + Grafana monitoring stack that can be installed alongside MasterDnsVPN during server setup. When the user opts in at the start of installation, the system automatically provisions:

- A Python Prometheus exporter that collects service status, active sessions, and traffic metrics via systemctl, iptables, and journalctl
- Dockerized Prometheus and Grafana with a pre-built dashboard (server status, sessions, throughput, traffic panels)
- Systemd service for the exporter with automatic restart
- Firewall rules for Grafana (3000) and Prometheus (9090)

The monitoring module is fully self-contained under `monitoring/` and can also be installed standalone, ensuring it does not interfere with future project updates.

## Changes

- **`monitoring/`** — New self-contained module: exporter script, Docker Compose setup, Prometheus config, Grafana provisioning (datasource + dashboard), install script, and README
- **`server_linux_install.sh`** — Added early opt-in prompt for monitoring, auto-download of the monitoring module via git clone, sourcing of `monitoring/install.sh`, combined final summary with Grafana access details, and `set -e` safety fixes

## Test plan

- [x] Fresh install with monitoring = **yes**: all components deploy, summary shows Grafana URL/credentials
- [x] Fresh install with monitoring = **no**: no monitoring artifacts created, standard summary only
- [x] Grafana health endpoint returns OK on port 3000
- [x] Exporter `/metrics` returns all expected gauges and counters
- [x] Prometheus target health is `up` with zero scrape errors
- [x] Non-interactive (no TTY) install gracefully skips monitoring prompt