### PR TITLE
Compact recently-closed heap to prevent stale entry accumulation

### DIFF
--- a/internal/client/client_utils.go
+++ b/internal/client/client_utils.go
@@ -398,6 +398,24 @@ func (c *Client) pruneRecentlyClosedLocked(now time.Time) {
 		delete(c.recentlyClosedStreams, entry.streamID)
 		heap.Pop(&c.recentlyClosedHeap)
 	}
+	c.compactRecentlyClosedHeapLocked()
+}
+
+func (c *Client) compactRecentlyClosedHeapLocked() {
+	mapLen := len(c.recentlyClosedStreams)
+	threshold := mapLen + mapLen/2
+	if threshold < mapLen+4 {
+		threshold = mapLen + 4
+	}
+	if len(c.recentlyClosedHeap) <= threshold {
+		return
+	}
+	rebuilt := make(recentlyClosedHeap, 0, mapLen)
+	for streamID, expires := range c.recentlyClosedStreams {
+		rebuilt = append(rebuilt, recentlyClosedEntry{streamID: streamID, expires: expires})
+	}
+	heap.Init(&rebuilt)
+	c.recentlyClosedHeap = rebuilt
 }
 
 func (c *Client) evictRecentlyClosedLocked(capacity int) {

--- a/internal/client/tcp_stream_test.go
+++ b/internal/client/tcp_stream_test.go
@@ -492,3 +492,30 @@ func TestFakeConnReadDeadlineReturnsTimeout(t *testing.T) {
 		t.Fatalf("fakeConn.Read timeout took too long: %v", elapsed)
 	}
 }
+
+func TestRecentlyClosedHeapStaleEntryGrowth(t *testing.T) {
+	c := buildTCPTestClient()
+	now := time.Now()
+
+	for cycle := 0; cycle < 10; cycle++ {
+		for id := uint16(1); id <= 50; id++ {
+			c.rememberClosedStream(id, "RST acknowledged", now)
+		}
+		now = now.Add(100 * time.Millisecond)
+	}
+
+	c.recentlyClosedMu.Lock()
+	heapSize := len(c.recentlyClosedHeap)
+	mapSize := len(c.recentlyClosedStreams)
+	c.recentlyClosedMu.Unlock()
+
+	t.Logf("After 10 cycles of 50 stream IDs: heap=%d map=%d ratio=%.2f", heapSize, mapSize, float64(heapSize)/float64(mapSize))
+
+	maxAllowed := mapSize + mapSize/2
+	if maxAllowed < mapSize+4 {
+		maxAllowed = mapSize + 4
+	}
+	if heapSize > maxAllowed {
+		t.Errorf("heap (%d) exceeded 1.5x the map size (%d, threshold %d), compaction should prevent this", heapSize, mapSize, maxAllowed)
+	}
+}


### PR DESCRIPTION
## Summary
Add heap compaction to `pruneRecentlyClosedLocked` to prevent unbounded growth of the `recentlyClosedHeap` when stream IDs are rapidly recycled.

## Changes
- Add `compactRecentlyClosedHeapLocked` -- rebuilds the heap from the authoritative map when the heap exceeds 1.5x the map size (with a minimum floor of `mapLen + 4`)
- Call it at the end of every `pruneRecentlyClosedLocked` cycle
- Add `TestRecentlyClosedHeapStaleEntryGrowth` regression test that simulates 10 cycles of 50 recycled stream IDs

## Why
When a stream ID is re-remembered with a new expiration, a new entry is pushed onto the heap but the old (stale) entry remains. The lazy-deletion in `pruneRecentlyClosedLocked` only cleans up entries at the front of the heap. Under pathological stream ID recycling, the heap grew to ~1.9x the map size. With compaction, peak ratio is capped at ~1.5x.

## Test plan
- `go test -race ./internal/client/...` -- all tests pass, race-clean
- `TestRecentlyClosedHeapStaleEntryGrowth` confirms heap stays within 1.5x bound