### PR TITLE
Fixed a possible apt-get update error

### DIFF
--- a/server_linux_install.sh
+++ b/server_linux_install.sh
@@ -225,12 +225,17 @@ else log_error "No supported package manager found (apt/dnf/yum)."; fi
 log_header "Preparing Environment"
 log_info "Installing dependencies..."
 if [[ "$PM" == "apt" ]]; then
-  apt-get update -y >/dev/null 2>&1
-  apt-get install -y lsof net-tools wget unzip curl ca-certificates iproute2 procps irqbalance >/dev/null 2>&1
+  if ! apt-get update -y >/dev/null; then
+    log_error "apt-get update failed. Check the output above for details."
+  fi
+  apt-get install -y lsof net-tools wget unzip curl ca-certificates iproute2 procps irqbalance >/dev/null
 elif [[ "$PM" == "dnf" ]]; then
-  dnf -y install lsof net-tools wget unzip curl ca-certificates iproute procps-ng irqbalance >/dev/null 2>&1
+  dnf -y install lsof net-tools wget unzip curl ca-certificates iproute procps-ng irqbalance >/dev/null
 else
-  yum -y install lsof net-tools wget unzip curl ca-certificates iproute procps-ng irqbalance >/dev/null 2>&1
+  yum -y install lsof net-tools wget unzip curl ca-certificates iproute procps-ng irqbalance >/dev/null
+fi
+if [ "$?" -ne 0 ]; then
+  log_error "Some dependencies may have failed to install. Check the output above for details."
 fi
 require_cmd ss
 require_cmd unzip


### PR DESCRIPTION
Due to the strict `set -euo pipefail` settings at the beginning of the script, the execution cut off silently right after printing `"[INFO] Installing dependencies..."` (line 226).

![image.png](https://github.com/user-attachments/assets/a728d44e-26a5-4561-bbbe-4b9686b2ecbe)

Debugging revealed that `apt-get update` was failing due to an unrelated issue with a third-party `speedtest` package. Because this package is non-essential for installing MasterDnsVPN, I modified the script to safely handle repository error drops and prevent these minor, non-fatal update failures from crashing the entire deployment process.
