### PR TITLE
fix: return NXDOMAIN for non-tunnel DNS queries

### DIFF
--- a/internal/dnsparser/response.go
+++ b/internal/dnsparser/response.go
@@ -40,6 +40,10 @@ func BuildNoDataResponseFromLite(request []byte, parsed LitePacket) ([]byte, err
 	return buildNoDataResponseLite(request, parsed)
 }
 
+func BuildNameErrorResponseFromLite(request []byte, parsed LitePacket) ([]byte, error) {
+	return buildAuthoritativeResponseWithRCodeLite(request, parsed, Enums.DNSR_CODE_NAME_ERROR)
+}
+
 func BuildFormatErrorResponse(request []byte) ([]byte, error) {
 	return buildResponseWithRCode(request, Enums.DNSR_CODE_FORMAT_ERROR)
 }
@@ -102,6 +106,14 @@ func buildResponseWithRCode(request []byte, rcode uint8) ([]byte, error) {
 }
 
 func buildResponseWithRCodeLite(request []byte, parsed LitePacket, rcode uint8) ([]byte, error) {
+	return buildResponseWithFlagsLite(request, parsed, buildResponseFlags(parsed.Header.Flags, rcode))
+}
+
+func buildAuthoritativeResponseWithRCodeLite(request []byte, parsed LitePacket, rcode uint8) ([]byte, error) {
+	return buildResponseWithFlagsLite(request, parsed, buildAuthoritativeResponseFlags(parsed.Header.Flags, rcode))
+}
+
+func buildResponseWithFlagsLite(request []byte, parsed LitePacket, flags uint16) ([]byte, error) {
 	if len(request) < dnsHeaderSize {
 		return nil, ErrPacketTooShort
 	}
@@ -118,7 +130,7 @@ func buildResponseWithRCodeLite(request []byte, parsed LitePacket, rcode uint8) 
 
 	response := make([]byte, dnsHeaderSize+questionLen+optLen)
 	binary.BigEndian.PutUint16(response[0:2], parsed.Header.ID)
-	binary.BigEndian.PutUint16(response[2:4], buildResponseFlags(parsed.Header.Flags, rcode))
+	binary.BigEndian.PutUint16(response[2:4], flags)
 	binary.BigEndian.PutUint16(response[4:6], parsed.Header.QDCount)
 	binary.BigEndian.PutUint16(response[10:12], uint16(getARCount(optLen)))
 
@@ -188,6 +200,29 @@ func buildResponseFlags(requestFlags uint16, rcode uint8) uint16 {
 	// AA/TC are intentionally cleared unless we are relaying an upstream answer
 	// verbatim, in which case those bits come from the upstream packet itself.
 	flags &^= flagAA | flagTC
+	return flags
+}
+
+func buildAuthoritativeResponseFlags(requestFlags uint16, rcode uint8) uint16 {
+	const (
+		flagQR     uint16 = 1 << 15
+		flagAA     uint16 = 1 << 10
+		flagTC     uint16 = 1 << 9
+		flagRD     uint16 = 1 << 8
+		flagRA     uint16 = 1 << 7
+		flagCD     uint16 = 1 << 4
+		opcodeMask uint16 = 0x7800
+	)
+
+	flags := flagQR | flagAA | (requestFlags & opcodeMask) | uint16(rcode&0x0F)
+	if requestFlags&flagRD != 0 {
+		flags |= flagRD
+	}
+	if requestFlags&flagCD != 0 {
+		flags |= flagCD
+	}
+
+	flags &^= flagRA | flagTC
 	return flags
 }
 

--- a/internal/dnsparser/response_test.go
+++ b/internal/dnsparser/response_test.go
@@ -310,6 +310,55 @@ func TestBuildNoDataResponseFromLiteBuildsEmptyNoErrorResponse(t *testing.T) {
 	}
 }
 
+func TestBuildNameErrorResponseFromLiteBuildsAuthoritativeNXDOMAIN(t *testing.T) {
+	request := buildDNSQuery(0x6161, "outside.example", Enums.DNS_RECORD_TYPE_A, true)
+	request[3] |= 0x10 // CD
+
+	parsed, err := ParsePacketLite(request)
+	if err != nil {
+		t.Fatalf("ParsePacketLite returned error: %v", err)
+	}
+
+	response, err := BuildNameErrorResponseFromLite(request, parsed)
+	if err != nil {
+		t.Fatalf("BuildNameErrorResponseFromLite returned error: %v", err)
+	}
+
+	flags := binary.BigEndian.Uint16(response[2:4])
+	if got := flags & 0x000F; got != Enums.DNSR_CODE_NAME_ERROR {
+		t.Fatalf("unexpected rcode: got=%d want=%d", got, Enums.DNSR_CODE_NAME_ERROR)
+	}
+	if flags&(1<<15) == 0 {
+		t.Fatal("response must set QR")
+	}
+	if flags&(1<<10) == 0 {
+		t.Fatal("authoritative name error response must set AA")
+	}
+	if flags&(1<<7) != 0 {
+		t.Fatal("authoritative name error response must clear RA")
+	}
+	if flags&(1<<8) == 0 {
+		t.Fatal("response must preserve RD")
+	}
+	if flags&(1<<4) == 0 {
+		t.Fatal("response must preserve CD")
+	}
+	if got := binary.BigEndian.Uint16(response[6:8]); got != 0 {
+		t.Fatalf("unexpected ancount: got=%d want=0", got)
+	}
+
+	full, err := ParsePacket(response)
+	if err != nil {
+		t.Fatalf("ParsePacket(response) returned error: %v", err)
+	}
+	if len(full.Questions) != 1 || full.Questions[0].Name != "outside.example" {
+		t.Fatalf("unexpected question section: got=%+v", full.Questions)
+	}
+	if len(full.Additional) != 1 || full.Additional[0].Type != Enums.DNS_RECORD_TYPE_OPT {
+		t.Fatalf("response must preserve the OPT record")
+	}
+}
+
 func buildDNSQuery(id uint16, name string, qtype uint16, withOPT bool) []byte {
 	qname := encodeDNSName(name)
 	arCount := uint16(0)

--- a/internal/udpserver/server_ingress.go
+++ b/internal/udpserver/server_ingress.go
@@ -42,11 +42,15 @@ func (s *Server) handlePacket(packet []byte) []byte {
 		return s.buildNoDataResponseLiteLogged(packet, parsed, "domain-match-process-failed")
 	}
 
-	if decision.Action == domainMatcher.ActionFormatError || decision.Action == domainMatcher.ActionNoData {
+	if decision.Action == domainMatcher.ActionFormatError {
 		return s.buildNoDataResponseLiteLogged(packet, parsed, "domain-match-no-data")
 	}
 
-	return s.buildNoDataResponseLiteLogged(packet, parsed, "domain-match-no-data")
+	if decision.Action == domainMatcher.ActionNoData {
+		return s.buildNameErrorResponseLiteLogged(packet, parsed, "domain-match-name-error")
+	}
+
+	return s.buildNameErrorResponseLiteLogged(packet, parsed, "domain-match-name-error")
 }
 
 func (s *Server) handleTunnelCandidate(packet []byte, parsed DnsParser.LitePacket, decision domainMatcher.Decision) []byte {

--- a/internal/udpserver/server_ingress.go
+++ b/internal/udpserver/server_ingress.go
@@ -33,24 +33,24 @@ func (s *Server) handlePacket(packet []byte) []byte {
 	}
 
 	decision := s.domainMatcher.Match(parsed)
-	if decision.Action == domainMatcher.ActionProcess {
+	switch decision.Action {
+	case domainMatcher.ActionProcess:
 		response := s.handleTunnelCandidate(packet, parsed, decision)
 		if response != nil {
 			return response
 		}
 
 		return s.buildNoDataResponseLiteLogged(packet, parsed, "domain-match-process-failed")
+	case domainMatcher.ActionFormatError:
+		return s.buildFormatErrorResponseLiteLogged(packet, parsed, decision.Reason)
+	case domainMatcher.ActionNoData:
+		if decision.Reason == "unauthorized-domain" {
+			return s.buildNameErrorResponseLiteLogged(packet, parsed, decision.Reason)
+		}
+		return s.buildNoDataResponseLiteLogged(packet, parsed, decision.Reason)
+	default:
+		return s.buildNoDataResponseLiteLogged(packet, parsed, "domain-match-unknown-action")
 	}
-
-	if decision.Action == domainMatcher.ActionFormatError {
-		return s.buildFormatErrorResponseLiteLogged(packet, parsed, "domain-match-format-error")
-	}
-
-	if decision.Action == domainMatcher.ActionNoData {
-		return s.buildNameErrorResponseLiteLogged(packet, parsed, "domain-match-name-error")
-	}
-
-	return s.buildNameErrorResponseLiteLogged(packet, parsed, "domain-match-name-error")
 }
 
 func (s *Server) handleTunnelCandidate(packet []byte, parsed DnsParser.LitePacket, decision domainMatcher.Decision) []byte {

--- a/internal/udpserver/server_ingress.go
+++ b/internal/udpserver/server_ingress.go
@@ -43,7 +43,7 @@ func (s *Server) handlePacket(packet []byte) []byte {
 	}
 
 	if decision.Action == domainMatcher.ActionFormatError {
-		return s.buildNoDataResponseLiteLogged(packet, parsed, "domain-match-no-data")
+		return s.buildFormatErrorResponseLiteLogged(packet, parsed, "domain-match-format-error")
 	}
 
 	if decision.Action == domainMatcher.ActionNoData {

--- a/internal/udpserver/server_ingress_test.go
+++ b/internal/udpserver/server_ingress_test.go
@@ -57,7 +57,7 @@ func TestHandlePacketRejectsMatcherFormatErrorAsFORMERR(t *testing.T) {
 	}
 }
 
-func TestHandlePacketKeepsUnsupportedAllowedAQueryAsNXDOMAIN(t *testing.T) {
+func TestHandlePacketKeepsUnsupportedAllowedAQueryAsNoData(t *testing.T) {
 	server := &Server{
 		domainMatcher: domainMatcher.New([]string{"vpn.example.com"}, 3),
 	}
@@ -69,8 +69,11 @@ func TestHandlePacketKeepsUnsupportedAllowedAQueryAsNXDOMAIN(t *testing.T) {
 	}
 
 	flags := binary.BigEndian.Uint16(response[2:4])
-	if got := flags & 0x000F; got != Enums.DNSR_CODE_NAME_ERROR {
-		t.Fatalf("unexpected rcode: got=%d want=%d", got, Enums.DNSR_CODE_NAME_ERROR)
+	if got := flags & 0x000F; got != Enums.DNSR_CODE_NO_ERROR {
+		t.Fatalf("unexpected rcode: got=%d want=%d", got, Enums.DNSR_CODE_NO_ERROR)
+	}
+	if got := binary.BigEndian.Uint16(response[6:8]); got != 0 {
+		t.Fatalf("unexpected ancount: got=%d want=0", got)
 	}
 }
 

--- a/internal/udpserver/server_ingress_test.go
+++ b/internal/udpserver/server_ingress_test.go
@@ -1,0 +1,75 @@
+package udpserver
+
+import (
+	"encoding/binary"
+	"testing"
+
+	domainMatcher "masterdnsvpn-go/internal/domainmatcher"
+	Enums "masterdnsvpn-go/internal/enums"
+)
+
+func TestHandlePacketRejectsUnauthorizedDomainAsNXDOMAIN(t *testing.T) {
+	server := &Server{
+		domainMatcher: domainMatcher.New([]string{"vpn.example.com"}, 3),
+	}
+	request := buildTestDNSQuery(0x4242, "example.org", Enums.DNS_RECORD_TYPE_A)
+
+	response := server.handlePacket(request)
+	if response == nil {
+		t.Fatal("expected DNS response, got nil")
+	}
+
+	flags := binary.BigEndian.Uint16(response[2:4])
+	if got := flags & 0x000F; got != Enums.DNSR_CODE_NAME_ERROR {
+		t.Fatalf("unexpected rcode: got=%d want=%d", got, Enums.DNSR_CODE_NAME_ERROR)
+	}
+	if flags&(1<<7) != 0 {
+		t.Fatal("unauthorized-domain response must clear RA")
+	}
+	if flags&(1<<10) == 0 {
+		t.Fatal("unauthorized-domain response must set AA")
+	}
+	if flags&(1<<8) == 0 {
+		t.Fatal("unauthorized-domain response must preserve RD")
+	}
+	if got := binary.BigEndian.Uint16(response[4:6]); got != 1 {
+		t.Fatalf("unexpected qdcount: got=%d want=1", got)
+	}
+	if got := binary.BigEndian.Uint16(response[6:8]); got != 0 {
+		t.Fatalf("unexpected ancount: got=%d want=0", got)
+	}
+}
+
+func buildTestDNSQuery(id uint16, name string, qtype uint16) []byte {
+	qname := encodeTestDNSName(name)
+	packet := make([]byte, 12+len(qname)+4)
+	binary.BigEndian.PutUint16(packet[0:2], id)
+	binary.BigEndian.PutUint16(packet[2:4], 0x0100)
+	binary.BigEndian.PutUint16(packet[4:6], 1)
+
+	offset := 12
+	offset += copy(packet[offset:], qname)
+	binary.BigEndian.PutUint16(packet[offset:offset+2], qtype)
+	binary.BigEndian.PutUint16(packet[offset+2:offset+4], Enums.DNSQ_CLASS_IN)
+	return packet
+}
+
+func encodeTestDNSName(name string) []byte {
+	if name == "." || name == "" {
+		return []byte{0}
+	}
+
+	encoded := make([]byte, 0, len(name)+2)
+	labelStart := 0
+	for i := 0; i <= len(name); i++ {
+		if i != len(name) && name[i] != '.' {
+			continue
+		}
+
+		labelLen := i - labelStart
+		encoded = append(encoded, byte(labelLen))
+		encoded = append(encoded, name[labelStart:i]...)
+		labelStart = i + 1
+	}
+	return append(encoded, 0)
+}

--- a/internal/udpserver/server_ingress_test.go
+++ b/internal/udpserver/server_ingress_test.go
@@ -40,6 +40,40 @@ func TestHandlePacketRejectsUnauthorizedDomainAsNXDOMAIN(t *testing.T) {
 	}
 }
 
+func TestHandlePacketRejectsMatcherFormatErrorAsFORMERR(t *testing.T) {
+	server := &Server{
+		domainMatcher: domainMatcher.New([]string{"vpn.example.com"}, 3),
+	}
+	request := buildTestDNSQuery(0x5151, ".", Enums.DNS_RECORD_TYPE_TXT)
+
+	response := server.handlePacket(request)
+	if response == nil {
+		t.Fatal("expected DNS response, got nil")
+	}
+
+	flags := binary.BigEndian.Uint16(response[2:4])
+	if got := flags & 0x000F; got != Enums.DNSR_CODE_FORMAT_ERROR {
+		t.Fatalf("unexpected rcode: got=%d want=%d", got, Enums.DNSR_CODE_FORMAT_ERROR)
+	}
+}
+
+func TestHandlePacketKeepsUnsupportedAllowedAQueryAsNXDOMAIN(t *testing.T) {
+	server := &Server{
+		domainMatcher: domainMatcher.New([]string{"vpn.example.com"}, 3),
+	}
+	request := buildTestDNSQuery(0x6161, "probe.vpn.example.com", Enums.DNS_RECORD_TYPE_A)
+
+	response := server.handlePacket(request)
+	if response == nil {
+		t.Fatal("expected DNS response, got nil")
+	}
+
+	flags := binary.BigEndian.Uint16(response[2:4])
+	if got := flags & 0x000F; got != Enums.DNSR_CODE_NAME_ERROR {
+		t.Fatalf("unexpected rcode: got=%d want=%d", got, Enums.DNSR_CODE_NAME_ERROR)
+	}
+}
+
 func buildTestDNSQuery(id uint16, name string, qtype uint16) []byte {
 	qname := encodeTestDNSName(name)
 	packet := make([]byte, 12+len(qname)+4)

--- a/internal/udpserver/server_utils.go
+++ b/internal/udpserver/server_utils.go
@@ -52,6 +52,14 @@ func buildNameErrorResponseLite(packet []byte, parsed DnsParser.LitePacket) []by
 	return response
 }
 
+func buildFormatErrorResponseLite(packet []byte, parsed DnsParser.LitePacket) []byte {
+	response, err := DnsParser.BuildFormatErrorResponseFromLite(packet, parsed)
+	if err != nil {
+		return nil
+	}
+	return response
+}
+
 func (s *Server) buildNoDataResponseLogged(packet []byte, reason string) []byte {
 	return buildNoDataResponse(packet)
 }
@@ -62,6 +70,10 @@ func (s *Server) buildNoDataResponseLiteLogged(packet []byte, parsed DnsParser.L
 
 func (s *Server) buildNameErrorResponseLiteLogged(packet []byte, parsed DnsParser.LitePacket, reason string) []byte {
 	return buildNameErrorResponseLite(packet, parsed)
+}
+
+func (s *Server) buildFormatErrorResponseLiteLogged(packet []byte, parsed DnsParser.LitePacket, reason string) []byte {
+	return buildFormatErrorResponseLite(packet, parsed)
 }
 
 func isClosedStreamAwarePacketType(packetType uint8) bool {

--- a/internal/udpserver/server_utils.go
+++ b/internal/udpserver/server_utils.go
@@ -44,12 +44,24 @@ func buildNoDataResponseLite(packet []byte, parsed DnsParser.LitePacket) []byte 
 	return response
 }
 
+func buildNameErrorResponseLite(packet []byte, parsed DnsParser.LitePacket) []byte {
+	response, err := DnsParser.BuildNameErrorResponseFromLite(packet, parsed)
+	if err != nil {
+		return nil
+	}
+	return response
+}
+
 func (s *Server) buildNoDataResponseLogged(packet []byte, reason string) []byte {
 	return buildNoDataResponse(packet)
 }
 
 func (s *Server) buildNoDataResponseLiteLogged(packet []byte, parsed DnsParser.LitePacket, reason string) []byte {
 	return buildNoDataResponseLite(packet, parsed)
+}
+
+func (s *Server) buildNameErrorResponseLiteLogged(packet []byte, parsed DnsParser.LitePacket, reason string) []byte {
+	return buildNameErrorResponseLite(packet, parsed)
 }
 
 func isClosedStreamAwarePacketType(packetType uint8) bool {


### PR DESCRIPTION
## Summary
- add an authoritative NXDOMAIN response builder that clears RA while preserving the request question and OPT record
- use that response for domain matcher `ActionNoData` cases so unrelated DNS queries no longer look recursively answered
- cover the DNS response builder and `udpserver.handlePacket` path with tests

## Validation
- `go test ./internal/dnsparser ./internal/udpserver`
- `go test ./...`

Fixes #174