### PR TITLE
feat(client): implement FastStart for early connection and background resolver discovery

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-﻿# MasterDnsVPN Project 🔐
+# MasterDnsVPN Project 🔐
 
 ## | 🇮🇷 [فارسی](https://github.com/masterking32/MasterDnsVPN/blob/main/README_FA.MD) | 🇬🇧 [English](https://github.com/masterking32/MasterDnsVPN/blob/main/README.MD) | 🇷🇺 [Русский](https://github.com/masterking32/MasterDnsVPN/blob/main/README_RU.MD) | 🇨🇳 [中文](https://github.com/masterking32/MasterDnsVPN/blob/main/README_ZH.MD) | 🇪🇸 [Español](https://github.com/masterking32/MasterDnsVPN/blob/main/README_ES.MD) | 🇮🇹 [Italiano](https://github.com/masterking32/MasterDnsVPN/blob/main/README_IT.MD) |
 
@@ -606,7 +606,7 @@ These settings are critical on the server:
 | `SETUP_PACKET_DUPLICATION_COUNT` | `2` | clamp to valid range in code | Similar to `PACKET_DUPLICATION_COUNT`, but used for setup-sensitive packets such as stream creation and other critical control events. |
 | `STREAM_RESOLVER_FAILOVER_RESEND_THRESHOLD` | `2` | If `<1`, fallback applies | If a stream accumulates repeated resend pressure on the same preferred resolver, the client may fail over that stream to another resolver.<br>This threshold controls how quickly that happens. |
 | `STREAM_RESOLVER_FAILOVER_COOLDOWN` | `2.5` | If `<=0`, fallback applies | Minimum delay between two failovers for the same stream.<br>This prevents unstable oscillation between resolvers. |
-| `RECHECK_INACTIVE_SERVERS_ENABLED` | `true` | `true/false` | Enables background rechecks for currently disabled or unhealthy resolvers.<br>If disabled, once a resolver becomes unusable, it will stay disabled until restart or manual rebuild. |
+| `RECHECK_INACTIVE_SERVERS_ENABLED` | `true` | `true/false` | Enables background rechecks for currently disabled or unhealthy resolvers.<br>Also activates **FastStart**: client connects immediately once `RX_TX_WORKERS` working resolvers are validated, then discovers remaining resolvers in the background.<br>If disabled, once a resolver becomes unusable, it will stay disabled until restart, and initial startup will synchronously scan 100% of resolvers. |
 | `AUTO_DISABLE_TIMEOUT_SERVERS` | `true` | `true/false` | Enables automatic disabling of resolvers that keep timing out and show no successful activity. |
 | `AUTO_DISABLE_TIMEOUT_WINDOW_SECONDS` | `30.0` | If `<=0`, fallback applies | Time window used to decide whether a resolver is timeout-only.<br>If all observations in this window are timeouts, it may be disabled. |
 | `BASE_ENCODE_DATA` | `false` | `true/false` | If enabled, payloads are encoded in a base-safe format before tunneling.<br>This usually reduces payload efficiency, but can help in strict resolver environments. |

--- a/client_config.toml.simple
+++ b/client_config.toml.simple
@@ -139,6 +139,9 @@ STREAM_RESOLVER_FAILOVER_COOLDOWN = 2.5
 
 # If true, resolvers rejected during initial MTU testing are rechecked in the
 # background using the current synced upload/download MTUs.
+# Also activates FastStart: connects immediately once a minimal working set of
+# resolvers (matching RX_TX_WORKERS) is validated, discovering and adding the
+# remaining resolvers in the background.
 RECHECK_INACTIVE_SERVERS_ENABLED = true
 
 # If true, a resolver is runtime-disabled when it stays timeout-only across the

--- a/internal/client/fast_start_test.go
+++ b/internal/client/fast_start_test.go
@@ -1,0 +1,201 @@
+// ==============================================================================
+// MasterDnsVPN
+// Author: MasterkinG32
+// Github: https://github.com/masterking32
+// Year: 2026
+// ==============================================================================
+package client
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"masterdnsvpn-go/internal/config"
+	"masterdnsvpn-go/internal/security"
+	"masterdnsvpn-go/internal/udpserver"
+)
+
+func startMockMTUDNSListener(t *testing.T, domain string) (*net.UDPConn, int, *atomic.Int32) {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("failed to listen UDP: %v", err)
+	}
+
+	serverCfg := config.DefaultServerConfig()
+	serverCfg.Domain = []string{domain}
+	serverCfg.MinVPNLabelLength = 3
+	serverCfg.DataEncryptionMethod = 0
+	serverCodec, err := security.NewCodec(0, "")
+	if err != nil {
+		t.Fatalf("server codec init failed: %v", err)
+	}
+	server := udpserver.New(serverCfg, nil, serverCodec)
+
+	var queryCount atomic.Int32
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, remoteAddr, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			queryCount.Add(1)
+			query := make([]byte, n)
+			copy(query, buf[:n])
+			response := server.HandlePacket(query)
+			if len(response) > 0 {
+				_, _ = conn.WriteToUDP(response, remoteAddr)
+			}
+		}
+	}()
+
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	return conn, port, &queryCount
+}
+
+func createTestFastStartClient(t *testing.T, cfg config.ClientConfig) *Client {
+	t.Helper()
+	codec, err := security.NewCodec(cfg.DataEncryptionMethod, cfg.EncryptionKey)
+	if err != nil {
+		t.Fatalf("client codec init failed: %v", err)
+	}
+	client := New(cfg, nil, codec)
+	if err := client.BuildConnectionMap(); err != nil {
+		t.Fatalf("BuildConnectionMap failed: %v", err)
+	}
+	return client
+}
+
+func TestRunInitialMTUTests_FastStartExitsEarly(t *testing.T) {
+	domain := "v.example.com"
+
+	// Start 10 mock resolver listeners
+	conns := make([]*net.UDPConn, 10)
+	resolvers := make([]config.ResolverAddress, 10)
+	for i := 0; i < 10; i++ {
+		conn, port, _ := startMockMTUDNSListener(t, domain)
+		conns[i] = conn
+		resolvers[i] = config.ResolverAddress{IP: "127.0.0.1", Port: port}
+		defer conn.Close()
+	}
+
+	cfg := config.DefaultClientConfig()
+	cfg.Domains = []string{domain}
+	cfg.Resolvers = resolvers
+	cfg.RecheckInactiveServersEnabled = true
+	cfg.RX_TX_Workers = 2
+	cfg.MinUploadMTU = 100
+	cfg.MaxUploadMTU = 200
+	cfg.MinDownloadMTU = 200
+	cfg.MaxDownloadMTU = 400
+	cfg.MTUTestRetries = 1
+	cfg.MTUTestTimeout = 1.0
+
+	client := createTestFastStartClient(t, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := client.RunInitialMTUTests(ctx)
+	if err != nil {
+		t.Fatalf("RunInitialMTUTests failed: %v", err)
+	}
+
+	activeCount := client.balancer.ActiveCount()
+	if activeCount != 2 {
+		t.Fatalf("expected exactly 2 active resolvers after FastStart early exit, got=%d", activeCount)
+	}
+
+	totalCount := client.balancer.TotalCount()
+	if totalCount != 10 {
+		t.Fatalf("expected total 10 connections in balancer, got=%d", totalCount)
+	}
+}
+
+func TestRunInitialMTUTests_FullScanWhenRecheckDisabled(t *testing.T) {
+	domain := "v.example.com"
+
+	// Start 4 mock resolver listeners
+	conns := make([]*net.UDPConn, 4)
+	resolvers := make([]config.ResolverAddress, 4)
+	for i := 0; i < 4; i++ {
+		conn, port, _ := startMockMTUDNSListener(t, domain)
+		conns[i] = conn
+		resolvers[i] = config.ResolverAddress{IP: "127.0.0.1", Port: port}
+		defer conn.Close()
+	}
+
+	cfg := config.DefaultClientConfig()
+	cfg.Domains = []string{domain}
+	cfg.Resolvers = resolvers
+	cfg.RecheckInactiveServersEnabled = false // Disabled: must scan all
+	cfg.RX_TX_Workers = 2
+	cfg.MTUTestParallelism = 2
+	cfg.MinUploadMTU = 100
+	cfg.MaxUploadMTU = 200
+	cfg.MinDownloadMTU = 200
+	cfg.MaxDownloadMTU = 400
+	cfg.MTUTestRetries = 1
+	cfg.MTUTestTimeout = 1.0
+
+	client := createTestFastStartClient(t, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := client.RunInitialMTUTests(ctx)
+	if err != nil {
+		t.Fatalf("RunInitialMTUTests failed: %v", err)
+	}
+
+	activeCount := client.balancer.ActiveCount()
+	if activeCount != 4 {
+		t.Fatalf("expected all 4 active resolvers when recheck is disabled, got=%d", activeCount)
+	}
+}
+
+func TestRunInitialMTUTests_FallbackWhenFewerResolversWork(t *testing.T) {
+	domain := "v.example.com"
+
+	// 1 working mock resolver + 2 dead ports
+	conn, port, _ := startMockMTUDNSListener(t, domain)
+	defer conn.Close()
+
+	resolvers := []config.ResolverAddress{
+		{IP: "127.0.0.1", Port: port},
+		{IP: "127.0.0.1", Port: 59998}, // dead port
+		{IP: "127.0.0.1", Port: 59999}, // dead port
+	}
+
+	cfg := config.DefaultClientConfig()
+	cfg.Domains = []string{domain}
+	cfg.Resolvers = resolvers
+	cfg.RecheckInactiveServersEnabled = true
+	cfg.RX_TX_Workers = 3 // Targets 3, but only 1 will respond
+	cfg.MTUTestParallelism = 2
+	cfg.MinUploadMTU = 100
+	cfg.MaxUploadMTU = 200
+	cfg.MinDownloadMTU = 200
+	cfg.MaxDownloadMTU = 400
+	cfg.MTUTestRetries = 1
+	cfg.MTUTestTimeout = 0.1
+
+	client := createTestFastStartClient(t, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := client.RunInitialMTUTests(ctx)
+	if err != nil {
+		t.Fatalf("RunInitialMTUTests should succeed with remaining working resolver, failed: %v", err)
+	}
+
+	activeCount := client.balancer.ActiveCount()
+	if activeCount != 1 {
+		t.Fatalf("expected 1 active resolver, got=%d", activeCount)
+	}
+}

--- a/internal/client/mtu.go
+++ b/internal/client/mtu.go
@@ -324,8 +324,21 @@ func (c *Client) RunInitialMTUTests(ctx context.Context) error {
 		return ErrNoValidConnections
 	}
 
+	fastStart := c.cfg.RecheckInactiveServersEnabled
+	targetValid := len(scanConnections)
+	if fastStart {
+		minRequired := c.cfg.RX_TX_Workers
+		if minRequired < 1 {
+			minRequired = 1
+		}
+		targetValid = min(len(scanConnections), minRequired)
+	}
+
 	uploadCaps := c.precomputeUploadCaps()
 	workerCount := min(max(1, c.cfg.EffectiveMTUTestParallelism()), len(scanConnections))
+	if fastStart {
+		workerCount = min(workerCount, targetValid)
+	}
 	c.logMTUStart(workerCount)
 	c.prepareMTUSuccessOutputFile()
 
@@ -335,35 +348,55 @@ func (c *Client) RunInitialMTUTests(ctx context.Context) error {
 			if err := ctx.Err(); err != nil {
 				return nil
 			}
+			if fastStart && counters.valid.Load() >= int32(targetValid) {
+				break
+			}
 			conn := scanConnections[idx]
 			c.runConnectionMTUTest(ctx, conn, idx+1, len(scanConnections), uploadCaps[conn.Domain], counters)
 		}
 	} else {
-		jobs := make(chan int, len(scanConnections))
+		scanCtx, cancelScan := context.WithCancel(ctx)
+		defer cancelScan()
+
+		jobs := make(chan int, workerCount)
 		var wg sync.WaitGroup
 		for range workerCount {
 			wg.Go(func() {
 				for idx := range jobs {
-					if err := ctx.Err(); err != nil {
+					if scanCtx.Err() != nil {
+						return
+					}
+					if fastStart && counters.valid.Load() >= int32(targetValid) {
+						cancelScan()
 						return
 					}
 					conn := scanConnections[idx]
-					c.runConnectionMTUTest(ctx, conn, idx+1, len(scanConnections), uploadCaps[conn.Domain], counters)
+					c.runConnectionMTUTest(scanCtx, conn, idx+1, len(scanConnections), uploadCaps[conn.Domain], counters)
+					if fastStart && counters.valid.Load() >= int32(targetValid) {
+						cancelScan()
+					}
 				}
 			})
 		}
 
+	dispatchLoop:
 		for idx := range scanConnections {
+			if fastStart && counters.valid.Load() >= int32(targetValid) {
+				cancelScan()
+				break dispatchLoop
+			}
 			select {
-			case <-ctx.Done():
-				close(jobs)
-				wg.Wait()
-				return nil
+			case <-scanCtx.Done():
+				break dispatchLoop
 			case jobs <- idx:
 			}
 		}
 		close(jobs)
 		wg.Wait()
+
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
 	}
 
 	activeConns := c.balancer.ActiveConnections()
@@ -378,6 +411,14 @@ func (c *Client) RunInitialMTUTests(ctx context.Context) error {
 	c.applySyncedMTUState(minUpload, minDownload, minUploadChars)
 	c.appendMTUUsageSeparatorOnce()
 	c.logMTUCompletion(validConns)
+
+	if fastStart && len(validConns) < len(scanConnections) {
+		remaining := len(scanConnections) - len(validConns)
+		if c.log != nil {
+			c.log.Infof("⚡ <green>FastStart:</green> Initial connection ready with <cyan>%d</cyan> resolver(s). Background recheck will discover and test remaining <cyan>%d</cyan> resolver(s).", len(validConns), remaining)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -129,6 +129,10 @@ type ClientConfigFlagBinder struct {
 	flagToField map[string]string
 }
 
+func DefaultClientConfig() ClientConfig {
+	return defaultClientConfig()
+}
+
 func defaultClientConfig() ClientConfig {
 	return ClientConfig{
 		ProtocolType:                          "SOCKS5",

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -111,6 +111,10 @@ type ServerConfigFlagBinder struct {
 	flagToField map[string]string
 }
 
+func DefaultServerConfig() ServerConfig {
+	return defaultServerConfig()
+}
+
 func defaultServerConfig() ServerConfig {
 	return ServerConfig{
 		ProtocolType:                      "SOCKS5",

--- a/internal/udpserver/server.go
+++ b/internal/udpserver/server.go
@@ -173,6 +173,11 @@ func New(cfg config.ServerConfig, log *logger.Logger, codec *security.Codec) *Se
 	}
 }
 
+// HandlePacket processes an incoming raw DNS query packet and returns the generated DNS response.
+func (s *Server) HandlePacket(packet []byte) []byte {
+	return s.handlePacket(packet)
+}
+
 type throttledLogState struct {
 	mu   sync.Mutex
 	last map[string]int64


### PR DESCRIPTION
## Summary
When configured with large resolver lists (e.g. 50–100+ endpoints), the client previously blocked session initialization and local proxy (SOCKS5/DNS) startup until 100% of all resolvers were synchronously probed for MTU.

This PR introduces **FastStart**:
- When \RECHECK_INACTIVE_SERVERS_ENABLED = true\ (default), the initial MTU test completes early as soon as a minimal working set of resolvers (\min(TotalResolvers, max(1, RX_TX_WORKERS))\) is validated.
- The client connects and opens local proxy listeners immediately (~1–2s startup time).
- The remaining unscanned resolvers remain in the pool as \inactive\, where the existing background \unResolverHealthLoop\ discovers and reactivates them asynchronously without blocking user traffic.
- When \RECHECK_INACTIVE_SERVERS_ENABLED = false\, the legacy behavior is preserved (full 100% upfront scan).

## Key Changes
- **\internal/client/mtu.go\**: Added early-exit condition to \RunInitialMTUTests\ bounded by \	argetValid\, capped worker count during fast start, and added completion logs.
- **\internal/client/fast_start_test.go\**: Added comprehensive unit test suite (\TestRunInitialMTUTests_FastStartExitsEarly\, \TestRunInitialMTUTests_FullScanWhenRecheckDisabled\, \TestRunInitialMTUTests_FallbackWhenFewerResolversWork\).
- **\client_config.toml.simple\ & \README.MD\**: Documented FastStart behavior under \RECHECK_INACTIVE_SERVERS_ENABLED\.
- Exported helper methods in \internal/config\ and \internal/udpserver\ (\DefaultClientConfig\, \DefaultServerConfig\, \Server.HandlePacket\).

## Verification
- \go test -v ./internal/client -run TestRunInitialMTUTests\ -> PASS
- \go test ./...\ -> PASS across all packages
- \go build ./cmd/client && go build ./cmd/server\ -> PASS (clean build)